### PR TITLE
apiserver: switch charms to NewFacade and add support for CAAS.

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -129,7 +129,7 @@ func AllFacades() *facade.Registry {
 	reg("Block", 2, block.NewAPI)
 	reg("Bundle", 1, bundle.NewFacade)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
-	reg("Charms", 2, charms.NewAPI)
+	reg("Charms", 2, charms.NewFacade)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
 	reg("Client", 1, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacade)

--- a/apiserver/charms/state.go
+++ b/apiserver/charms/state.go
@@ -10,12 +10,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-type charmsAccess interface {
-	Charm(curl *charm.URL) (*state.Charm, error)
-	AllCharms() ([]*state.Charm, error)
-	ModelTag() names.ModelTag
-}
-
 type stateShim struct {
 	state *state.State
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -58,6 +58,8 @@ type Context interface {
 	Resources() Resources
 
 	// XXX for a given model either State() or CAASState() will return nil
+	IsCAAS() bool
+	IsIAAS() bool
 
 	// State returns, /sigh, a *State. As yet, there is no way
 	// around this; in the not-too-distant future, we hope, its

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -287,6 +287,18 @@ func (ctx *facadeContext) Resources() facade.Resources {
 	return ctx.r.resources
 }
 
+// IsCAAS returns whether the facade.Context interface has
+// an associated CAAS state.
+func (ctx *facadeContext) IsCAAS() bool {
+	return ctx.r.state.IsCAAS()
+}
+
+// IsIAAS returns whether the facade.Context interface has
+// an associated IAAS state.
+func (ctx *facadeContext) IsIAAS() bool {
+	return ctx.r.state.IsIAAS()
+}
+
 // State is part of of the facade.Context interface.
 func (ctx *facadeContext) State() *state.State {
 	return ctx.r.state.State()


### PR DESCRIPTION
This avoids having the charms.NewAPI function wrapped with a call
that only supports *state.State, making the facade callable on a
CAAS model. Also remove stateShim since it serves no purpose.