### PR TITLE
apiserver: use stateUnion through most of the apiserver HTTP code.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -469,7 +469,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
-			rst, err := st.Resources()
+			rst, err := st.State().Resources()
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
@@ -487,7 +487,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			opener, err := resourceadapters.NewResourceOpener(st, tag.Id())
+			opener, err := resourceadapters.NewResourceOpener(st.State(), tag.Id())
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -39,7 +39,7 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 	defer releaser()
 
-	backups, closer := newBackups(st)
+	backups, closer := newBackups(st.State())
 	defer closer.Close()
 
 	switch req.Method {

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -85,7 +85,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if err := h.handle(st, params, socket, h.ctxt.stop()); err != nil {
+		if err := h.handle(st.State(), params, socket, h.ctxt.stop()); err != nil {
 			if isBrokenPipe(err) {
 				logger.Tracef("debug-log handler stopped (client disconnected)")
 			} else {

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -43,10 +43,10 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 	// access these endpoints.
 
 	ok, err := common.HasPermission(
-		st.UserPermission,
+		st.State().UserPermission,
 		entity.Tag(),
 		permission.SuperuserAccess,
-		st.ControllerTag(),
+		st.State().ControllerTag(),
 	)
 	if err != nil {
 		return err
@@ -55,12 +55,12 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 		return nil
 	}
 
-	controllerModel, err := st.ControllerModel()
+	controllerModel, err := st.State().ControllerModel()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	ok, err = common.HasPermission(
-		st.UserPermission,
+		st.State().UserPermission,
 		entity.Tag(),
 		permission.ReadAccess,
 		controllerModel.ModelTag(),

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -47,7 +47,7 @@ type LoggingStrategy interface {
 
 type agentLoggingStrategy struct {
 	ctxt       httpContext
-	st         *state.State
+	st         *stateUnion
 	releaser   func()
 	version    version.Number
 	entity     names.Tag
@@ -89,8 +89,8 @@ func (s *agentLoggingStrategy) Authenticate(req *http.Request) error {
 
 // Start creates the underlying DB logger. Part of LoggingStrategy.
 func (s *agentLoggingStrategy) Start() {
-	s.filePrefix = s.st.ModelUUID() + ":"
-	s.dbLogger = state.NewEntityDbLogger(s.st, s.entity, s.version)
+	s.filePrefix = s.st.State().ModelUUID() + ":"
+	s.dbLogger = state.NewEntityDbLogger(s.st.State(), s.entity, s.version)
 }
 
 // Log writes the record to the file and entity loggers. Part of

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -41,7 +41,7 @@ func newLogStreamEndpointHandler(ctxt httpContext) *logStreamEndpointHandler {
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		return &logStreamState{st}, releaser, nil
+		return &logStreamState{st.State()}, releaser, nil
 	}
 	return &logStreamEndpointHandler{
 		stopCh:    ctxt.stop(),

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -17,7 +17,7 @@ import (
 
 type migrationLoggingStrategy struct {
 	ctxt       httpContext
-	st         *state.State
+	st         *stateUnion
 	releaser   func()
 	filePrefix string
 	dbLogger   *state.DbLogger
@@ -57,9 +57,9 @@ func (s *migrationLoggingStrategy) Authenticate(req *http.Request) error {
 
 // Start creates the destination DB logger. Part of LoggingStrategy.
 func (s *migrationLoggingStrategy) Start() {
-	s.filePrefix = s.st.ModelUUID() + ":"
-	s.dbLogger = state.NewDbLogger(s.st)
-	s.tracker = newLogTracker(s.st)
+	s.filePrefix = s.st.State().ModelUUID() + ":"
+	s.dbLogger = state.NewDbLogger(s.st.State())
+	s.tracker = newLogTracker(s.st.State())
 }
 
 // Log writes the given record to the DB and to the backup file

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -97,7 +97,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 // NOTE(axw) it is important that the client and server choose their
 // own nonces, because reusing a nonce means that the key-stream can
 // be revealed.
-func (h *registerUserHandler) processPost(req *http.Request, st *state.State) (
+func (h *registerUserHandler) processPost(req *http.Request, st *stateUnion) (
 	names.UserTag, *params.SecretKeyLoginResponse, error,
 ) {
 
@@ -125,7 +125,7 @@ func (h *registerUserHandler) processPost(req *http.Request, st *state.State) (
 	}
 
 	// Decrypt the ciphertext with the user's secret key (if it has one).
-	user, err := st.User(userTag)
+	user, err := st.State().User(userTag)
 	if err != nil {
 		return failure(err)
 	}
@@ -155,7 +155,7 @@ func (h *registerUserHandler) processPost(req *http.Request, st *state.State) (
 
 	// Respond with the CA-cert and password, encrypted again with the
 	// secret key.
-	responsePayload, err := h.getSecretKeyLoginResponsePayload(st, userTag)
+	responsePayload, err := h.getSecretKeyLoginResponsePayload(st.State(), userTag)
 	if err != nil {
 		return failure(errors.Trace(err))
 	}

--- a/apiserver/resources_mig.go
+++ b/apiserver/resources_mig.go
@@ -20,7 +20,7 @@ import (
 // resourcesMigrationUploadHandler handles resources uploads for model migrations.
 type resourcesMigrationUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*stateUnion, func(), error)
 }
 
 func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *ht
 
 // processPost handles resources upload POST request after
 // authentication.
-func (h *resourcesMigrationUploadHandler) processPost(r *http.Request, st *state.State) (resource.Resource, error) {
+func (h *resourcesMigrationUploadHandler) processPost(r *http.Request, st *stateUnion) (resource.Resource, error) {
 	var empty resource.Resource
 	query := r.URL.Query()
 
@@ -73,7 +73,7 @@ func (h *resourcesMigrationUploadHandler) processPost(r *http.Request, st *state
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
-	rSt, err := st.Resources()
+	rSt, err := st.State().Resources()
 	if err != nil {
 		return empty, errors.Trace(err)
 	}

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 )
 
@@ -44,7 +43,7 @@ func (h *RestHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type modelRestHandler struct {
 	ctxt          httpContext
 	dataDir       string
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*stateUnion, func(), error)
 }
 
 // ServeGet handles http GET requests.
@@ -63,7 +62,7 @@ func (h *modelRestHandler) ServeGet(w http.ResponseWriter, r *http.Request) erro
 }
 
 // processGet handles a ReST GET request after authentication.
-func (h *modelRestHandler) processGet(r *http.Request, w http.ResponseWriter, st *state.State) error {
+func (h *modelRestHandler) processGet(r *http.Request, w http.ResponseWriter, st *stateUnion) error {
 	query := r.URL.Query()
 	entity := query.Get(":entity")
 	// TODO(wallyworld) - support more than just "remote-application"
@@ -76,10 +75,10 @@ func (h *modelRestHandler) processGet(r *http.Request, w http.ResponseWriter, st
 }
 
 // processRemoteApplication handles a request for attributes on remote applications.
-func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.ResponseWriter, st *state.State) error {
+func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.ResponseWriter, st *stateUnion) error {
 	query := r.URL.Query()
 	name := query.Get(":name")
-	remoteApp, err := st.RemoteApplication(name)
+	remoteApp, err := st.State().RemoteApplication(name)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
This also wires up the CAASState pool for stateForRequestUnauthenticated
and always maps to the "admin" user for stateForRequestAuthenticated.