### PR TITLE
api,cmd/modelcmd: bring model type through to store.

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -16,6 +16,7 @@ import (
 type UserModel struct {
 	Name           string
 	UUID           string
+	Type           string
 	Owner          string
 	LastConnection *time.Time
 }

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -170,6 +170,7 @@ func (c *Client) ListModels(user string) ([]base.UserModel, error) {
 		result[i] = base.UserModel{
 			Name:           model.Name,
 			UUID:           model.UUID,
+			Type:           model.Type,
 			Owner:          owner.Id(),
 			LastConnection: model.LastConnection,
 		}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -239,7 +239,10 @@ func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controller
 		return errors.Trace(err)
 	}
 	for _, model := range models {
-		modelDetails := jujuclient.ModelDetails{ModelUUID: model.UUID}
+		modelDetails := jujuclient.ModelDetails{
+			ModelUUID: model.UUID,
+			Type:      jujuclient.ModelType(model.Type),
+		}
 		owner := names.NewUserTag(model.Owner)
 		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
 		if err := store.UpdateModel(controllerName, modelName, modelDetails); err != nil {


### PR DESCRIPTION
This makes RefreshModels work correctly, rather than losing
the Juju model types.