### PR TITLE
state: use correct collections for caasapplications/caasmodels.

### DIFF
--- a/state/caasapplication.go
+++ b/state/caasapplication.go
@@ -344,7 +344,7 @@ func (a *CAASApplication) SetCharm(cfg SetCharmConfig) (err error) {
 		if a.doc.CharmURL.String() == cfg.Charm.URL().String() {
 			// Charm URL already set; just update the force flag and channel.
 			ops = append(ops, txn.Op{
-				C:  applicationsC,
+				C:  caasApplicationsC,
 				Id: a.doc.DocID,
 				Update: bson.D{{"$set", bson.D{
 					{"cs-channel", channel},
@@ -386,7 +386,7 @@ func (a *CAASApplication) String() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // application has been removed.
 func (a *CAASApplication) Refresh() error {
-	applications, closer := a.st.db().GetCollection(applicationsC)
+	applications, closer := a.st.db().GetCollection(caasApplicationsC)
 	defer closer()
 
 	err := applications.FindId(a.doc.DocID).One(&a.doc)
@@ -499,7 +499,7 @@ func (a *CAASApplication) addCAASUnitOpsWithCons(args caasApplicationAddCAASUnit
 // incUnitCountOp returns the operation to increment the application's unit count.
 func (a *CAASApplication) incUnitCountOp(asserts bson.D) txn.Op {
 	op := txn.Op{
-		C:      applicationsC,
+		C:      caasApplicationsC,
 		Id:     a.doc.DocID,
 		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
 	}
@@ -518,7 +518,7 @@ func (a *CAASApplication) AddCAASUnit() (caasunit *CAASUnit, err error) {
 	}
 
 	if err := a.st.runTransaction(ops); err == txn.ErrAborted {
-		if alive, err := isAlive(a.st, applicationsC, a.doc.DocID); err != nil {
+		if alive, err := isAlive(a.st, caasApplicationsC, a.doc.DocID); err != nil {
 			return nil, err
 		} else if !alive {
 			return nil, errors.New("application is not alive")

--- a/state/caasmodel.go
+++ b/state/caasmodel.go
@@ -193,3 +193,13 @@ func (m *CAASModel) refresh(query mongo.Query) error {
 	}
 	return err
 }
+
+// assertCAASModelActiveOp returns a txn.Op that asserts the given
+// CAAS model UUID refers to an Alive model.
+func assertCAASModelActiveOp(modelUUID string) txn.Op {
+	return txn.Op{
+		C:      caasModelsC,
+		Id:     modelUUID,
+		Assert: isAliveDoc,
+	}
+}

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -209,7 +209,7 @@ func (st *CAASState) AddCAASApplication(args AddCAASApplicationArgs) (_ *CAASApp
 		return nil, errors.Trace(err)
 	}
 
-	if exists, err := isNotDead(st, applicationsC, args.Name); err != nil {
+	if exists, err := isNotDead(st, caasApplicationsC, args.Name); err != nil {
 		return nil, errors.Trace(err)
 	} else if exists {
 		return nil, errors.Errorf("application already exists")
@@ -252,7 +252,7 @@ func (st *CAASState) AddCAASApplication(args AddCAASApplicationArgs) (_ *CAASApp
 			}
 			*/
 			// Ensure a local application with the same name doesn't exist.
-			if exists, err := isNotDead(st, applicationsC, args.Name); err != nil {
+			if exists, err := isNotDead(st, caasApplicationsC, args.Name); err != nil {
 				return nil, errors.Trace(err)
 			} else if exists {
 				return nil, errLocalApplicationExists
@@ -261,7 +261,7 @@ func (st *CAASState) AddCAASApplication(args AddCAASApplicationArgs) (_ *CAASApp
 		// The addCAASApplicationOps does not include the model alive assertion,
 		// so we add it here.
 		ops := []txn.Op{
-			assertModelActiveOp(st.ModelUUID()),
+			assertCAASModelActiveOp(st.ModelUUID()),
 		}
 		addOps, err := addCAASApplicationOps(st, addCAASApplicationOpsArgs{
 			appDoc:   appDoc,
@@ -287,12 +287,12 @@ func (st *CAASState) AddCAASApplication(args AddCAASApplicationArgs) (_ *CAASApp
 	// At the last moment before inserting the application, prime status history.
 	probablyUpdateStatusHistory(st, app.globalKey(), statusDoc)
 
-	if err = st.db().Run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Refresh to pick the txn-revno.
-	if err = app.Refresh(); err != nil {
+	if err := app.Refresh(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return app, nil


### PR DESCRIPTION
When working with caasapplications we need to use caasApplicationsC,
rather than applicationsC. Also provide an assertCAASModelActiveOp
that works on caasModelsC instead of modelsC and removes the
migration-mode constraint.