### PR TITLE
state: add support for CAAS FindEntity and User.

### DIFF
--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -112,8 +112,12 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
 	}
 
 	if st.IsCAAS() {
-		// XXX Just fake it for the prototype for now.
-		entity, err := ctxt.srv.state.User(names.NewUserTag("admin"))
+		// XXX For now, just fake authentication for the prototype.
+		authTag, err := names.ParseTag(req.AuthTag)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		entity, err := st.CAASState().FindEntity(authTag)
 		if err != nil {
 			return nil, nil, nil, errors.Trace(err)
 		}

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -142,6 +142,22 @@ func (st *CAASState) Close() error {
 	return nil
 }
 
+// FindEntity returns the entity with the given tag.
+//
+// The returned value can be of type *User or *Application, depending
+// on the tag.
+func (st *CAASState) FindEntity(tag names.Tag) (Entity, error) {
+	id := tag.Id()
+	switch tag := tag.(type) {
+	case names.UserTag:
+		return st.User(tag)
+	case names.ApplicationTag:
+		return st.CAASApplication(id)
+	default:
+		return nil, errors.Errorf("unsupported tag %T", tag)
+	}
+}
+
 // modelSetupOps returns the transactions necessary to set up a CAAS model.
 func (st *CAASState) modelSetupOps(modelUUID, controllerUUID string, args CAASModelArgs) ([]txn.Op, error) {
 	/* XXX
@@ -306,6 +322,11 @@ func (st *CAASState) ModelConfig() (*config.Config, error) {
 		return nil, errors.Trace(err)
 	}
 	return config.New(config.NoDefaults, modelSettings.Map())
+}
+
+// User returns the state User for the given name.
+func (st *CAASState) User(tag names.UserTag) (*User, error) {
+	return getUser(st, tag)
 }
 
 func (st *CAASState) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {


### PR DESCRIPTION
Rework state.User so that it can be loaded via a modelBackend
interface. Also change the stateForRequestAuthenticated code so
that it makes use of the req.AuthTag, rather than always loading
the "admin" user entity.