### PR TITLE
local and potentially faster update

### DIFF
--- a/caasoperator/Makefile
+++ b/caasoperator/Makefile
@@ -40,3 +40,11 @@ operator_pod != kubectl get po -o name | cut -d '/' -f 2 | grep juju-operator
 
 update-operator: push
 	kubectl exec ${operator_pod} -- kill 1
+
+kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' '
+local-update-operator: image
+	docker save ${DOCKER_USERNAME}/caasoperator | pv | gzip > /tmp/caasoperator-image.tar.gz
+	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/caasoperator-image.tar.gz $(wm):/tmp/caasoperator-image.tar.gz ; )
+	$(foreach wm,$(kubeworkers), juju run --timeout 30m -m ${JUJU_K8S_MODEL} --machine $(wm) -- "zcat /tmp/caasoperator-image.tar.gz | docker load" ; )
+	@echo restarting ${operator_pod}
+	kubectl exec ${operator_pod} -- kill 1

--- a/worker/caasprovisioner/k8s.go
+++ b/worker/caasprovisioner/k8s.go
@@ -123,7 +123,7 @@ func deployOperator(client *kubernetes.Clientset, appName string, configMapName 
 			Containers: []v1.Container{{
 				Name:            "juju-operator",
 				Image:           "mikemccracken/caasoperator",
-				ImagePullPolicy: v1.PullAlways,
+				ImagePullPolicy: v1.PullIfNotPresent,
 				Args:            []string{"caasoperator", "--application-name", appName, "--debug"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name: configVolName,


### PR DESCRIPTION
Adds a makefile target for development that instead of pushing to
docker hub, builds the image, saves it, then copies it to all workers,
loads it there, and restarts the operator pod.

We copy it to all the workers in case the pod is resurrected on
another node.

Changes the imagepullpolicy to ensure that the local image is used.

Depending on the number of workers, this might be faster than pushing
to docker hub.


use it like this: 
```
make local-update-operator JUJU_K8S_MODEL=controller:model 
```


Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>