### PR TITLE
Provide a CAASProvisioner facade and use this for the provisioner.

### DIFF
--- a/api/caasprovisioner/provisioner.go
+++ b/api/caasprovisioner/provisioner.go
@@ -1,0 +1,94 @@
+// Copyright 2013, 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/watcher"
+)
+
+type Config struct {
+	Endpoint string
+	CAData   []byte
+	CertData []byte
+	KeyData  []byte
+}
+
+type State struct {
+	*common.ControllerConfigAPI
+
+	facade base.FacadeCaller
+}
+
+func NewState(caller base.APICaller) *State {
+	facadeCaller := base.NewFacadeCaller(caller, "CAASProvisioner")
+	return &State{
+		ControllerConfigAPI: common.NewControllerConfig(facadeCaller),
+
+		facade: facadeCaller,
+	}
+}
+
+func (st *State) APIHostPorts() ([][]network.HostPort, error) {
+	var result params.APIHostPortsResult
+	if err := st.facade.FacadeCall("APIHostPorts", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.NetworkHostsPorts(), nil
+}
+
+func (st *State) ControllerTag() (names.ControllerTag, error) {
+	var result params.StringResult
+	if err := st.facade.FacadeCall("ControllerTag", nil, &result); err != nil {
+		return names.NewControllerTag(""), err
+	}
+	if err := result.Error; err != nil {
+		return names.NewControllerTag(""), err
+	}
+	return names.NewControllerTag(result.Result), nil
+}
+
+func (st *State) ModelTag() (names.ModelTag, error) {
+	var result params.StringResult
+	if err := st.facade.FacadeCall("ModelTag", nil, &result); err != nil {
+		return names.NewModelTag(""), err
+	}
+	if err := result.Error; err != nil {
+		return names.NewModelTag(""), err
+	}
+	return names.NewModelTag(result.Result), nil
+}
+
+func (st *State) ProvisioningConfig() (*Config, error) {
+	var result params.CAASProvisioningConfig
+	if err := st.facade.FacadeCall("ProvisioningConfig", nil, &result); err != nil {
+		return nil, err
+	}
+	return &Config{
+		Endpoint: result.Endpoint,
+		CAData:   result.CAData,
+		CertData: result.CertData,
+		KeyData:  result.KeyData,
+	}, nil
+}
+
+// WatchApplications returns a StringsWatcher that notifies of
+// changes to the lifecycles of applications in the current model.
+func (st *State) WatchApplications() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	if err := st.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
+		return nil, err
+	}
+	if err := result.Error; err != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -25,6 +25,7 @@ var facadeVersions = map[string]int{
 	"Bundle":                       1,
 	"CAASApplication":              1,
 	"CAASClient":                   1,
+	"CAASProvisioner":              1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/caasapplication"
 	"github.com/juju/juju/apiserver/caasclient"
 	"github.com/juju/juju/apiserver/caasoperator"
+	"github.com/juju/juju/apiserver/caasprovisioner"
 	"github.com/juju/juju/apiserver/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/charms" // ModelUser Write
 	"github.com/juju/juju/apiserver/cleaner"
@@ -223,6 +224,7 @@ func AllFacades() *facade.Registry {
 	reg("CAASApplication", 1, caasapplication.NewFacade)
 	reg("CAASClient", 1, caasclient.NewFacade)
 	reg("CAASOperator", 1, caasoperator.NewFacade)
+	reg("CAASProvisioner", 1, caasprovisioner.NewFacade)
 
 	regRaw("AllWatcher", 1, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))
 	// Note: AllModelWatcher uses the same infrastructure as AllWatcher

--- a/apiserver/caasprovisioner/provisioner.go
+++ b/apiserver/caasprovisioner/provisioner.go
@@ -1,0 +1,103 @@
+// Copyright 2012, 2013, 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.caasprovisioner")
+
+type API struct {
+	*common.ControllerConfigAPI
+
+	auth      facade.Authorizer
+	model     *state.CAASModel
+	resources facade.Resources
+	state     *state.CAASState
+}
+
+// NewFacade provides the signature required for facade registration.
+func NewFacade(ctx facade.Context) (*API, error) {
+	if !ctx.IsCAAS() {
+		return nil, errors.New("not a CAAS state")
+	}
+
+	authorizer := ctx.Auth()
+	resources := ctx.Resources()
+	state := ctx.CAASState()
+
+	model, err := state.CAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+
+	return &API{
+		ControllerConfigAPI: common.NewControllerConfig(state),
+
+		auth:      authorizer,
+		model:     model,
+		resources: resources,
+		state:     state,
+	}, nil
+}
+
+func (a *API) APIHostPorts() (params.APIHostPortsResult, error) {
+	servers, err := a.state.APIHostPorts()
+	if err != nil {
+		return params.APIHostPortsResult{}, err
+	}
+	return params.APIHostPortsResult{
+		Servers: params.FromNetworkHostsPorts(servers),
+	}, nil
+}
+
+func (a *API) ControllerTag() (params.StringResult, error) {
+	return params.StringResult{Result: a.state.ControllerTag().String()}, nil
+}
+
+func (a *API) ModelTag() (params.StringResult, error) {
+	return params.StringResult{Result: a.state.ModelTag().String()}, nil
+}
+
+// ProvisioningConfig returns the configuration to be used when provisioning
+// applications.
+func (a *API) ProvisioningConfig() (params.CAASProvisioningConfig, error) {
+	return params.CAASProvisioningConfig{
+		Endpoint: a.model.Endpoint(),
+		CAData:   a.model.CAData(),
+		CertData: a.model.CertData(),
+		KeyData:  a.model.KeyData(),
+	}, nil
+}
+
+// ModelUUID returns the model UUID to connect to the environment
+// that the current connection is for.
+func (a *API) ModelUUID() (params.StringResult, error) {
+	return params.StringResult{Result: a.state.ModelUUID()}, nil
+}
+
+// WatchApplications starts a StringsWatcher to watch applications deployed to
+// this model.
+func (a *API) WatchApplications(args params.WatchApplications) (params.StringsWatchResult, error) {
+	watch := a.state.WatchApplications()
+	// Consume the initial event and forward it to the result.
+	if changes, ok := <-watch.Changes(); ok {
+		return params.StringsWatchResult{
+			StringsWatcherId: a.resources.Register(watch),
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -28,3 +28,10 @@ type CAASUnit struct {
 	Tag  string `json:"tag"`
 	Life Life   `json:"life"`
 }
+
+type CAASProvisioningConfig struct {
+	Endpoint string `json:"endpoint"`
+	CAData   []byte `json:"ca-data"`
+	CertData []byte `json:"cert-data"`
+	KeyData  []byte `json:"key-data"`
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -40,6 +40,12 @@ type WatchContainers struct {
 	Params []WatchContainer `json:"params"`
 }
 
+// WatchApplications holds the arguments for making a WatchApplications
+// API call.
+type WatchApplications struct {
+	Params []string `json:"application-tag"`
+}
+
 // CharmURL identifies a single charm URL.
 type CharmURL struct {
 	URL string `json:"url"`

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -24,6 +24,7 @@ var caasModelFacadeNames = set.NewStrings(
 	"CAASApplication",
 	"CAASClient",
 	"CAASOperator",
+	"CAASProvisioner",
 )
 
 func caasModelFacadesOnly(facadeName, _ string) error {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
 	"github.com/juju/juju/worker/applicationscaler"
+	"github.com/juju/juju/worker/caasprovisioner"
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
 	"github.com/juju/juju/worker/cleaner"
@@ -314,6 +315,36 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	return result
 }
 
+// CAASManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a CAAS model, as configured.
+func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	result := dependency.Manifolds{
+		// The first group are foundational; the agent and clock
+		// which wrap those supplied in config, and the api-caller
+		// through which everything else communicates with the
+		// controller.
+		agentName: agent.Manifold(config.Agent),
+		clockName: clockManifold(config.Clock),
+		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+			AgentName:          agentName,
+			AgentConfigChanged: config.AgentConfigChanged,
+		}),
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:     agentName,
+			APIOpen:       api.Open,
+			NewConnection: apicaller.OnlyConnect,
+			Filter:        apiConnectFilter,
+		}),
+
+		caasProvisionerName: caasprovisioner.Manifold(caasprovisioner.ManifoldConfig{
+			AgentName:          agentName,
+			APICallerName:      apiCallerName,
+			NewProvisionerFunc: caasprovisioner.New,
+		}),
+	}
+	return result
+}
+
 // clockManifold expresses a Clock as a ValueWorker manifold.
 func clockManifold(clock clock.Clock) dependency.Manifold {
 	return dependency.Manifold{
@@ -393,6 +424,7 @@ const (
 	environTrackerName       = "environ-tracker"
 	undertakerName           = "undertaker"
 	spaceImporterName        = "space-importer"
+	caasProvisionerName      = "caas-provisioner"
 	computeProvisionerName   = "compute-provisioner"
 	storageProvisionerName   = "storage-provisioner"
 	firewallerName           = "firewaller"

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2728,7 +2728,6 @@ func (st *CAASState) WatchApplications() StringsWatcher {
 	return newLifecycleWatcher(st, caasApplicationsC, nil, isLocalID(st), nil)
 }
 
-
 // WatchCleanups starts and returns a CleanupWatcher.
 func (st *CAASState) WatchCleanups() NotifyWatcher {
 	return newNotifyCollWatcher(st, cleanupsC, isLocalID(st))

--- a/worker/caasmodelworkermanager/worker.go
+++ b/worker/caasmodelworkermanager/worker.go
@@ -28,7 +28,7 @@ type NewStateFunc func() (*state.CAASState, error)
 // NewWorkerFunc should return a worker responsible for running
 // all a model's required workers; and for returning nil when
 // there's no more model to manage.
-type NewWorkerFunc func(string, NewStateFunc) (worker.Worker, error)
+type NewWorkerFunc func(string, string) (worker.Worker, error)
 
 // Config holds the dependencies and configuration necessary to run
 // a model worker manager.
@@ -134,14 +134,7 @@ func (m *caasModelWorkerManager) starter(modelUUID string) func() (worker.Worker
 	return func() (worker.Worker, error) {
 		logger.Debugf("starting workers for CAAS model %q", modelUUID)
 
-		// XXX CAAS: this is bad! Workers should never use
-		// *State/*CAASState directly. This is purely a shortcut for
-		// the CAAS prototype and should never make it into production
-		// code.
-		newCAASState := func() (*state.CAASState, error) {
-			return m.config.Backend.ForCAASModel(names.NewModelTag(modelUUID))
-		}
-		worker, err := m.config.NewWorker(modelUUID, newCAASState)
+		worker, err := m.config.NewWorker(m.config.ControllerUUID, modelUUID)
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot manage CAAS model %q", modelUUID)
 		}

--- a/worker/caasprovisioner/manifold.go
+++ b/worker/caasprovisioner/manifold.go
@@ -1,0 +1,56 @@
+// Copyright 2015, 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	apicaasprovisioner "github.com/juju/juju/api/caasprovisioner"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines an environment provisioner's dependencies. It's not
+// currently clear whether it'll be easier to extend this type to include all
+// provisioners, or to create separate (Environ|Container)Manifold[Config]s;
+// for now we dodge the question because we don't need container provisioners
+// in dependency engines. Yet.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+
+	NewProvisionerFunc func(*apicaasprovisioner.State, agent.Config) (worker.Worker, error)
+}
+
+// Manifold creates a manifold that runs a CAAS provisioner. See the
+// ManifoldConfig type for discussion about how this can/should evolve.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			api := apicaasprovisioner.NewState(apiCaller)
+			agentConfig := agent.CurrentConfig()
+			w, err := config.NewProvisionerFunc(api, agentConfig)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
+	}
+}


### PR DESCRIPTION
This also switches the CAAS model workers to manifolds/dependency
engine, which will allow for other workers to be more readily run
(such as the cleaner).