### PR TITLE
Make CAAS application removal possible.

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -341,6 +341,9 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			NewProvisionerFunc: caasprovisioner.New,
 		}),
+		stateCleanerName: cleaner.Manifold(cleaner.ManifoldConfig{
+			APICallerName: apiCallerName,
+		}),
 	}
 	return result
 }

--- a/state/caasapplication.go
+++ b/state/caasapplication.go
@@ -122,12 +122,46 @@ func (a *CAASApplication) destroyOps() ([]txn.Op, error) {
 	if a.doc.Life == Dying {
 		return nil, errAlreadyDying
 	}
-	return []txn.Op{{
+	// If the application has no units, the application can also be
+	// removed.
+	// TODO: Also check relations.
+	if a.doc.UnitCount == 0 {
+		hasLastRefs := bson.D{{"life", Alive}, {"unitcount", 0}}
+		removeOps, err := a.removeOps(hasLastRefs)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return removeOps, nil
+	}
+
+	ops := []txn.Op{}
+
+	// In all other cases, application removal will be handled as a consequence
+	// of the removal of the last unit or relation referencing it. If any
+	// relations have been removed, they'll be caught by the operations
+	// collected above; but if any has been added, we need to abort and add
+	// a destroy op for that relation too. In combination, it's enough to
+	// check for count equality: an add/remove will not touch the count, but
+	// will be caught by virtue of being a remove.
+	notLastRefs := bson.D{
+		{"life", Alive},
+	}
+	// With respect to unit count, a changing value doesn't matter, so long
+	// as the count's equality with zero does not change, because all we care
+	// about is that *some* unit is, or is not, keeping the application from
+	// being removed: the difference between 1 unit and 1000 is irrelevant.
+	if a.doc.UnitCount > 0 {
+		ops = append(ops, newCleanupOp(cleanupUnitsForDyingApplication, a.doc.Name))
+		notLastRefs = append(notLastRefs, bson.D{{"unitcount", bson.D{{"$gt", 0}}}}...)
+	} else {
+		notLastRefs = append(notLastRefs, bson.D{{"unitcount", 0}}...)
+	}
+	return append(ops, txn.Op{
 		C:      caasApplicationsC,
 		Id:     a.doc.DocID,
-		Assert: bson.D{{"life", Alive}},
+		Assert: notLastRefs,
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
-	}}, nil
+	}), nil
 }
 
 // removeOps returns the operations required to remove the CAAS
@@ -650,6 +684,11 @@ func (a *CAASApplication) ConfigSettings() (charm.Settings, error) {
 // entries. This method is used by both the *State.AddCAASApplication method and the
 // migration import code.
 func addCAASApplicationOps(st *CAASState, args addCAASApplicationOpsArgs) ([]txn.Op, error) {
+	charmRefOps, err := appCharmIncRefOps(st, args.appDoc.Name, args.appDoc.CharmURL, true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	app := newCAASApplication(st, args.appDoc)
 
 	settingsKey := app.settingsKey()
@@ -658,6 +697,7 @@ func addCAASApplicationOps(st *CAASState, args addCAASApplicationOpsArgs) ([]txn
 		createSettingsOp(settingsC, settingsKey, args.settings),
 		// XXX addModelCAASApplicationRefOp(st, app.Name()),
 	}
+	ops = append(ops, charmRefOps...)
 	ops = append(ops, txn.Op{
 		C:      caasApplicationsC,
 		Id:     app.Name(),

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -701,8 +701,112 @@ func (st *State) cleanupAttachmentsForDyingFilesystem(filesystemId string) (err 
 	return nil
 }
 
+// Cleanup removes all documents that were previously marked for removal, if
+// any such exist. It should be called periodically by at least one element
+// of the system.
 func (st *CAASState) Cleanup() (err error) {
-	return errors.New("unimplemented")
+	var doc cleanupDoc
+	cleanups, closer := st.db().GetCollection(cleanupsC)
+	defer closer()
+	iter := cleanups.Find(nil).Iter()
+	defer closeIter(iter, &err, "reading cleanup document")
+	for iter.Next(&doc) {
+		var err error
+		logger.Debugf("running %q cleanup: %q", doc.Kind, doc.Prefix)
+		switch doc.Kind {
+		//case cleanupRelationSettings:
+		//	err = st.cleanupRelationSettings(doc.Prefix)
+		case cleanupCharm:
+			err = st.cleanupCharm(doc.Prefix)
+		case cleanupUnitsForDyingApplication:
+			err = st.cleanupUnitsForDyingApplication(doc.Prefix)
+		//case cleanupDyingUnit:
+		//	err = st.cleanupDyingUnit(doc.Prefix)
+		case cleanupRemovedUnit:
+			err = st.cleanupRemovedUnit(doc.Prefix)
+		//case cleanupApplicationsForDyingModel:
+		//	err = st.cleanupApplicationsForDyingModel()
+		//case cleanupModelsForDyingController:
+		//	err = st.cleanupModelsForDyingController()
+		default:
+			err = errors.Errorf("unknown cleanup kind %q", doc.Kind)
+		}
+		if err != nil {
+			logger.Errorf("cleanup failed for %v(%q): %v", doc.Kind, doc.Prefix, err)
+			continue
+		}
+		ops := []txn.Op{{
+			C:      cleanupsC,
+			Id:     doc.DocID,
+			Remove: true,
+		}}
+		if err := st.runTransaction(ops); err != nil {
+			return errors.Annotate(err, "cannot remove empty cleanup document")
+		}
+	}
+	return nil
+}
+
+// cleanupCharm is speculative: it can abort without error for many
+// reasons, because it's triggered somewhat overenthusiastically for
+// simplicity's sake.
+func (st *CAASState) cleanupCharm(charmURL string) error {
+	curl, err := charm.ParseURL(charmURL)
+	if err != nil {
+		return errors.Annotatef(err, "invalid charm URL %v", charmURL)
+	}
+
+	ch, err := st.Charm(curl)
+	if errors.IsNotFound(err) {
+		// Charm already removed.
+		return nil
+	} else if err != nil {
+		return errors.Annotate(err, "reading charm")
+	}
+
+	err = ch.Destroy()
+	switch errors.Cause(err) {
+	case nil:
+	case errCharmInUse:
+		// No cleanup necessary at this time.
+		return nil
+	default:
+		return errors.Annotate(err, "destroying charm")
+	}
+
+	if err := ch.Remove(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// cleanupDyingUnit marks resources owned by the unit as dying, to ensure
+// cleanupUnitsForDyingApplication sets all units with the given prefix to Dying,
+// if they are not already Dying or Dead. It's expected to be used when a
+// application is destroyed.
+func (st *CAASState) cleanupUnitsForDyingApplication(applicationname string) (err error) {
+	// This won't miss units, because a Dying application cannot have units
+	// added to it. But we do have to remove the units themselves via
+	// individual transactions, because they could be in any state at all.
+	units, closer := st.db().GetCollection(caasUnitsC)
+	defer closer()
+
+	unit := CAASUnit{st: st}
+	sel := bson.D{{"caasapplication", applicationname}, {"life", Alive}}
+	iter := units.Find(sel).Iter()
+	defer closeIter(iter, &err, "reading unit document")
+	for iter.Next(&unit.doc) {
+		if err := unit.Destroy(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupRemovedUnit takes care of all the final cleanup required when
+// a unit is removed.
+func (st *CAASState) cleanupRemovedUnit(unitId string) error {
+	return nil
 }
 
 func closeIter(iter *mgo.Iter, errOut *error, message string) {


### PR DESCRIPTION
This change enables the cleaner for CAAS models, adds cleanup
code to handle dying applications, fixes unit and application
destroy/removal, and corrects charm refcounting on CAAS
applications.