### PR TITLE
Add initial support for relations in CAAS models

### DIFF
--- a/api/caasapplication/client.go
+++ b/api/caasapplication/client.go
@@ -124,3 +124,10 @@ func (c *Client) AddCAASUnits(appName string, numUnits int) ([]string, error) {
 	}
 	return result.Units, nil
 }
+
+func (c *Client) AddCAASRelation(endpoints ...string) (*params.AddRelationResults, error) {
+	var addRelRes params.AddRelationResults
+	params := params.AddRelation{Endpoints: endpoints}
+	err := c.facade.FacadeCall("AddRelation", params, &addRelRes)
+	return &addRelRes, err
+}

--- a/apiserver/caasprovisioner/provisioner.go
+++ b/apiserver/caasprovisioner/provisioner.go
@@ -5,12 +5,12 @@ package caasprovisioner
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasprovisioner")

--- a/apiserver/caasprovisioner/provisioner.go
+++ b/apiserver/caasprovisioner/provisioner.go
@@ -5,12 +5,12 @@ package caasprovisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasprovisioner")

--- a/state/endpoint.go
+++ b/state/endpoint.go
@@ -41,7 +41,7 @@ func (ep Endpoint) String() string {
 	return ep.ApplicationName + ":" + ep.Name
 }
 
-// CanRelateTo returns whether a relation may be established between e and other.
+// CanRelateTo returns whether a relation may be established between ep and other.
 func (ep Endpoint) CanRelateTo(other Endpoint) bool {
 	return ep.ApplicationName != other.ApplicationName &&
 		ep.Interface == other.Interface &&


### PR DESCRIPTION
This allows for a 'juju relate' to be run, with the relation being recorded.