### PR TITLE
Add support for relation status and removal in CAAS models

### DIFF
--- a/api/caasapplication/client.go
+++ b/api/caasapplication/client.go
@@ -131,3 +131,8 @@ func (c *Client) AddCAASRelation(endpoints ...string) (*params.AddRelationResult
 	err := c.facade.FacadeCall("AddRelation", params, &addRelRes)
 	return &addRelRes, err
 }
+
+func (c *Client) DestroyCAASRelation(endpoints ...string) error {
+	params := params.DestroyRelation{Endpoints: endpoints}
+	return c.facade.FacadeCall("DestroyRelation", params, nil)
+}

--- a/apiserver/caasapplication/facade.go
+++ b/apiserver/caasapplication/facade.go
@@ -262,3 +262,22 @@ func (facade *Facade) AddRelation(args params.AddRelation) (params.AddRelationRe
 	}
 	return params.AddRelationResults{Endpoints: outEps}, nil
 }
+
+// DestroyRelation removes the relation between the specified endpoints.
+func (facade *Facade) DestroyRelation(args params.DestroyRelation) error {
+	/*if err := facade.checkCanWrite(); err != nil {
+		return err
+	}
+	if err := facade.check.RemoveAllowed(); err != nil {
+		return errors.Trace(err)
+	}*/
+	eps, err := facade.backend.InferEndpoints(args.Endpoints...)
+	if err != nil {
+		return err
+	}
+	rel, err := facade.backend.EndpointsRelation(eps...)
+	if err != nil {
+		return err
+	}
+	return rel.Destroy()
+}

--- a/apiserver/caasprovisioner/provisioner.go
+++ b/apiserver/caasprovisioner/provisioner.go
@@ -5,12 +5,12 @@ package caasprovisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasprovisioner")

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -652,6 +652,17 @@ func aliveCAASApplication(st *CAASState, name string) (ApplicationEntity, error)
 	return app, err
 }
 
+// EndpointsRelation returns the existing relation with the given endpoints.
+func (st *CAASState) EndpointsRelation(endpoints ...Endpoint) (*Relation, error) {
+	return st.KeyRelation(relationKey(endpoints))
+}
+
+// KeyRelation returns the existing relation with the given key (which can
+// be derived unambiguously from the relation's endpoints).
+func (st *CAASState) KeyRelation(key string) (*Relation, error) {
+	return keyRelation(st, key)
+}
+
 // AllRelations returns all relations in the model ordered by id.
 func (st *CAASState) AllRelations() (relations []*Relation, err error) {
 	return allRelations(st)

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -651,3 +651,8 @@ func aliveCAASApplication(st *CAASState, name string) (ApplicationEntity, error)
 	}
 	return app, err
 }
+
+// AllRelations returns all relations in the model ordered by id.
+func (st *CAASState) AllRelations() (relations []*Relation, err error) {
+	return allRelations(st)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1806,6 +1806,10 @@ func (st *State) Relation(id int) (*Relation, error) {
 
 // AllRelations returns all relations in the model ordered by id.
 func (st *State) AllRelations() (relations []*Relation, err error) {
+	return allRelations(st)
+}
+
+func allRelations(st modelBackend) (relations []*Relation, err error) {
 	relationsCollection, closer := st.db().GetCollection(relationsC)
 	defer closer()
 

--- a/state/state.go
+++ b/state/state.go
@@ -1774,6 +1774,10 @@ func (st *State) EndpointsRelation(endpoints ...Endpoint) (*Relation, error) {
 // KeyRelation returns the existing relation with the given key (which can
 // be derived unambiguously from the relation's endpoints).
 func (st *State) KeyRelation(key string) (*Relation, error) {
+	return keyRelation(st, key)
+}
+
+func keyRelation(st modelBackend, key string) (*Relation, error) {
 	relations, closer := st.db().GetCollection(relationsC)
 	defer closer()
 


### PR DESCRIPTION
This includes relation information in the status data returned
for a CAAS model, such that it can be displayed in the juju
client. Additionally, support for relation removal has been added.