### PR TITLE
api/caasprovisioner: Fix double-tagging for models and controllers

### DIFF
--- a/api/caasprovisioner/provisioner.go
+++ b/api/caasprovisioner/provisioner.go
@@ -52,7 +52,7 @@ func (st *State) ControllerTag() (names.ControllerTag, error) {
 	if err := result.Error; err != nil {
 		return names.NewControllerTag(""), err
 	}
-	return names.NewControllerTag(result.Result), nil
+	return names.ParseControllerTag(result.Result)
 }
 
 func (st *State) ModelTag() (names.ModelTag, error) {
@@ -63,7 +63,7 @@ func (st *State) ModelTag() (names.ModelTag, error) {
 	if err := result.Error; err != nil {
 		return names.NewModelTag(""), err
 	}
-	return names.NewModelTag(result.Result), nil
+	return names.ParseModelTag(result.Result)
 }
 
 func (st *State) ProvisioningConfig() (*Config, error) {

--- a/worker/caasprovisioner/k8s.go
+++ b/worker/caasprovisioner/k8s.go
@@ -72,7 +72,7 @@ func ensureConfigMap(client *kubernetes.Clientset, appName string, newConfig new
 	}
 	if exists {
 		logger.Infof("ConfigMap %s already exists", mapName)
-	}else{
+	} else {
 		config, err := newConfig(appName)
 		if err != nil {
 			return "", errors.Annotate(err, "creating config")

--- a/worker/caasprovisioner/k8s.go
+++ b/worker/caasprovisioner/k8s.go
@@ -70,7 +70,9 @@ func ensureConfigMap(client *kubernetes.Clientset, appName string, newConfig new
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	if !exists {
+	if exists {
+		logger.Infof("ConfigMap %s already exists", mapName)
+	}else{
 		config, err := newConfig(appName)
 		if err != nil {
 			return "", errors.Annotate(err, "creating config")


### PR DESCRIPTION
Fixes operator API connection