### PR TITLE
Enable remoterelations worker on CAAS models.

### DIFF
--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -42,8 +42,7 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	pool := &mockStatePool{s.st}
-	api, err := remoterelations.NewRemoteRelationsAPI(s.st, pool, s.resources, s.authorizer)
+	api, err := remoterelations.NewRemoteRelationsAPI(s.st, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -16,6 +16,8 @@ var commonModelFacadeNames = set.NewStrings(
 	"Charms",
 	"Cleaner",
 	"Pinger",
+	"RelationUnitsWatcher",
+	"RemoteRelations",
 )
 
 // caasModelFacadeNames lists facades that are only used with CAAS

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -331,6 +331,15 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		}),
 	}
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		result[remoteRelationsName] = remoterelations.Manifold(remoterelations.ManifoldConfig{
+			AgentName:                agentName,
+			APICallerName:            apiCallerName,
+			NewAPIConnForModel:       api.NewConnectionForModel,
+			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
+			NewWorker:                remoterelations.NewWorker,
+		})
+	}
 	return result
 }
 

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -686,6 +686,10 @@ func (st *CAASState) KeyRelation(key string) (*Relation, error) {
 	return keyRelation(st, key)
 }
 
+func (st *CAASState) Relation(id int) (*Relation, error) {
+	return relation(st, id)
+}
+
 // AllRelations returns all relations in the model ordered by id.
 func (st *CAASState) AllRelations() (relations []*Relation, err error) {
 	return allRelations(st)

--- a/state/relation.go
+++ b/state/relation.go
@@ -389,6 +389,12 @@ func (r *Relation) RelatedEndpoints(applicationname string) ([]Endpoint, error) 
 	return eps, nil
 }
 
+// CAASUnit returns a RelationUnit for the supplied unit.
+func (r *Relation) CAASUnit(u *CAASUnit) (*RelationUnit, error) {
+	const checkUnitLife = true
+	return r.unit(u.Name(), "", true, checkUnitLife)
+}
+
 // Unit returns a RelationUnit for the supplied unit.
 func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
 	const checkUnitLife = true

--- a/state/state.go
+++ b/state/state.go
@@ -1862,6 +1862,10 @@ func keyRelation(st modelBackend, key string) (*Relation, error) {
 
 // Relation returns the existing relation with the given id.
 func (st *State) Relation(id int) (*Relation, error) {
+	return relation(st, id)
+}
+
+func relation(st modelBackend, id int) (*Relation, error) {
 	relations, closer := st.db().GetCollection(relationsC)
 	defer closer()
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -347,6 +347,10 @@ func (st *State) WatchRemoteApplications() StringsWatcher {
 	return newLifecycleWatcher(st, remoteApplicationsC, nil, isLocalID(st), nil)
 }
 
+func (st *CAASState) WatchRemoteApplications() StringsWatcher {
+	return newLifecycleWatcher(st, remoteApplicationsC, nil, isLocalID(st), nil)
+}
+
 // WatchStorageAttachments returns a StringsWatcher that notifies of
 // changes to the lifecycles of all storage instances attached to the
 // specified unit.
@@ -2660,6 +2664,14 @@ func (w *notifyCollWatcher) loop() error {
 // WatchRemoteRelations returns a StringsWatcher that notifies of changes to
 // the lifecycles of the remote relations in the model.
 func (st *State) WatchRemoteRelations() StringsWatcher {
+	return watchRemoteRelations(st)
+}
+
+func (st *CAASState) WatchRemoteRelations() StringsWatcher {
+	return watchRemoteRelations(st)
+}
+
+func watchRemoteRelations(st modelBackend) StringsWatcher {
 	// Use a no-op transform func to record the known ids.
 	known := make(map[interface{}]bool)
 	tr := func(id string) string {


### PR DESCRIPTION
This makes the remoterelations facade work with both IAAS and CAAS
models, enables the RemoteRelations and RelationUnitsWatcher facades
for CAAS Models, adds necessary support/changes to state and enables
the worker.