### PR TITLE
state: additional support for CAAS remote relations

### DIFF
--- a/state/relation.go
+++ b/state/relation.go
@@ -411,8 +411,9 @@ func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {
 	}
 	switch st := r.st.(type) {
 	case *CAASState:
-		// XXX CAAS
-		return nil, errors.New("unsupported")
+		if _, err := st.RemoteApplication(serviceName); err != nil {
+			return nil, errors.Trace(err)
+		}
 	case *State:
 		if _, err := st.RemoteApplication(serviceName); err != nil {
 			return nil, errors.Trace(err)
@@ -437,8 +438,12 @@ func (r *Relation) IsCrossModel() (bool, error) {
 	for _, ep := range r.Endpoints() {
 		switch st := r.st.(type) {
 		case *CAASState:
-			// XXX CAAS
-			return false, errors.New("unsupported")
+			_, err := st.RemoteApplication(ep.ApplicationName)
+			if err == nil {
+				return true, nil
+			} else if !errors.IsNotFound(err) {
+				return false, errors.Trace(err)
+			}
 		case *State:
 			_, err := st.RemoteApplication(ep.ApplicationName)
 			if err == nil {

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -155,13 +155,16 @@ func (s *RemoteApplication) URL() (string, bool) {
 // Token returns the token for the remote application, provided by the remote
 // model to identify the service in future communications.
 func (s *RemoteApplication) Token() (string, error) {
-	st, ok := s.st.(*State)
-	if !ok {
-		// XXX CAAS
-		return "", errors.New("unsupported")
+	switch st := s.st.(type) {
+	case *CAASState:
+		r := st.RemoteEntities()
+		return r.GetToken(s.SourceModel(), s.Tag())
+	case *State:
+		r := st.RemoteEntities()
+		return r.GetToken(s.SourceModel(), s.Tag())
+	default:
+		return "", errors.Errorf("unknown state type %T", s.st)
 	}
-	r := st.RemoteEntities()
-	return r.GetToken(s.SourceModel(), s.Tag())
 }
 
 // Tag returns a name identifying the application.


### PR DESCRIPTION
Enable additional state handling for CAAS remote relations,
allowing the remoterelations worker to work correctly.