### PR TITLE
Support for relating caasapplications as a single unit

### DIFF
--- a/api/caasoperator/caasapplication.go
+++ b/api/caasoperator/caasapplication.go
@@ -107,6 +107,7 @@ func (s *CAASApplication) WatchRelations() (watcher.StringsWatcher, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.tag.String()}},
 	}
+	logger.Debugf("About to make WatchApplicationRelations facade call with args=%v", args)
 	err := s.st.facade.FacadeCall("WatchApplicationRelations", args, &results)
 	if err != nil {
 		return nil, err

--- a/api/caasoperator/caasoperator.go
+++ b/api/caasoperator/caasoperator.go
@@ -201,7 +201,13 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 
 // Relation returns the existing relation with the given tag.
 func (st *State) Relation(relationTag names.RelationTag) (*Relation, error) {
-	result, err := st.relation(relationTag, st.applicationTag)
+	// MMCC TEMP: to test relations in the prototype, we hard-code
+	// a single unit per application
+	fakeCaasUnitTag, err := names.ParseUnitTag("unit-" + st.applicationTag.Id() + "/0")
+	if err != nil {
+		return nil, err
+	}
+	result, err := st.relation(relationTag, fakeCaasUnitTag)
 	if err != nil {
 		return nil, err
 	}

--- a/api/caasoperator/caasoperator.go
+++ b/api/caasoperator/caasoperator.go
@@ -148,13 +148,10 @@ func (st *State) getOneAction(tag *names.ActionTag) (params.ActionResult, error)
 
 // CAASUnit provides access to methods of a state.CAASUnit through the facade.
 func (st *State) CAASUnit(tag names.UnitTag) (*CAASUnit, error) {
-	// TODO(mmcc): API: st.life() uses apiconnection, hardcoding:
-	// life, err := st.life(tag)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	life := params.Alive
-	// end todo
+	life, err := st.life(tag)
+	if err != nil {
+		return nil, err
+	}
 	return &CAASUnit{
 		tag:  tag,
 		life: life,

--- a/api/caasoperator/caasunit.go
+++ b/api/caasoperator/caasunit.go
@@ -498,34 +498,6 @@ func (op *CAASUnit) RequestReboot() error {
 	return nil
 }
 
-// JoinedRelations returns the tags of the relations the caasunit has joined.
-func (op *CAASUnit) JoinedRelations() ([]names.RelationTag, error) {
-	var results params.StringsResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: op.tag.String()}},
-	}
-	err := op.st.facade.FacadeCall("JoinedRelations", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	var relTags []names.RelationTag
-	for _, rel := range result.Result {
-		tag, err := names.ParseRelationTag(rel)
-		if err != nil {
-			return nil, err
-		}
-		relTags = append(relTags, tag)
-	}
-	return relTags, nil
-}
-
 // MeterStatus returns the meter status of the caasunit.
 func (op *CAASUnit) MeterStatus() (statusCode, statusInfo string, rErr error) {
 	var results params.MeterStatusResults
@@ -566,4 +538,32 @@ func (op *CAASUnit) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 	}
 	w := apiwatcher.NewNotifyWatcher(op.st.facade.RawAPICaller(), result)
 	return w, nil
+}
+
+// JoinedRelations returns the tags of the relations the application's units have joined.
+func (u *CAASUnit) JoinedRelations() ([]names.RelationTag, error) {
+	var results params.StringsResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: u.tag.String()}},
+	}
+	err := u.st.facade.FacadeCall("JoinedRelations", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	var relTags []names.RelationTag
+	for _, rel := range result.Result {
+		tag, err := names.ParseRelationTag(rel)
+		if err != nil {
+			return nil, err
+		}
+		relTags = append(relTags, tag)
+	}
+	return relTags, nil
 }

--- a/api/caasoperator/caasunit.go
+++ b/api/caasoperator/caasunit.go
@@ -498,6 +498,34 @@ func (op *CAASUnit) RequestReboot() error {
 	return nil
 }
 
+// JoinedRelations returns the tags of the relations the caasunit has joined.
+func (u *CAASUnit) JoinedRelations() ([]names.RelationTag, error) {
+	var results params.StringsResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: u.tag.String()}},
+	}
+	err := u.st.facade.FacadeCall("JoinedRelations", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	var relTags []names.RelationTag
+	for _, rel := range result.Result {
+		tag, err := names.ParseRelationTag(rel)
+		if err != nil {
+			return nil, err
+		}
+		relTags = append(relTags, tag)
+	}
+	return relTags, nil
+}
+
 // MeterStatus returns the meter status of the caasunit.
 func (op *CAASUnit) MeterStatus() (statusCode, statusInfo string, rErr error) {
 	var results params.MeterStatusResults
@@ -538,32 +566,4 @@ func (op *CAASUnit) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 	}
 	w := apiwatcher.NewNotifyWatcher(op.st.facade.RawAPICaller(), result)
 	return w, nil
-}
-
-// JoinedRelations returns the tags of the relations the application's units have joined.
-func (u *CAASUnit) JoinedRelations() ([]names.RelationTag, error) {
-	var results params.StringsResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: u.tag.String()}},
-	}
-	err := u.st.facade.FacadeCall("JoinedRelations", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	var relTags []names.RelationTag
-	for _, rel := range result.Result {
-		tag, err := names.ParseRelationTag(rel)
-		if err != nil {
-			return nil, err
-		}
-		relTags = append(relTags, tag)
-	}
-	return relTags, nil
 }

--- a/api/caasoperator/relation.go
+++ b/api/caasoperator/relation.go
@@ -52,7 +52,12 @@ func (r *Relation) Life() params.Life {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // relation has been removed.
 func (r *Relation) Refresh() error {
-	result, err := r.st.relation(r.tag, r.st.applicationTag)
+	fakeCaasUnitTag, err := names.ParseUnitTag("unit-" + r.st.applicationTag.Id() + "/0")
+	if err != nil {
+		return err
+	}
+
+	result, err := r.st.relation(r.tag, fakeCaasUnitTag)
 	if err != nil {
 		return err
 	}
@@ -81,7 +86,12 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 	// NOTE: This differs from state.Relation.Endpoint(), because when
 	// talking to the API, there's already an authenticated entity - the
 	// unit, and we can find out its application name.
-	result, err := r.st.relation(r.tag, r.st.applicationTag)
+	fakeCaasUnitTag, err := names.ParseUnitTag("unit-" + r.st.applicationTag.Id() + "/0")
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := r.st.relation(r.tag, fakeCaasUnitTag)
 	if err != nil {
 		return nil, err
 	}

--- a/api/caasoperator/relation.go
+++ b/api/caasoperator/relation.go
@@ -89,7 +89,7 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 }
 
 // Unit returns a RelationUnit for the supplied unit.
-func (r *Relation) Unit(u *CAASUnit) (*RelationUnit, error) {
+func (r *Relation) CAASUnit(u *CAASUnit) (*RelationUnit, error) {
 	if u == nil {
 		return nil, fmt.Errorf("unit is nil")
 	}

--- a/api/caasoperator/relation.go
+++ b/api/caasoperator/relation.go
@@ -89,7 +89,7 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 }
 
 // Unit returns a RelationUnit for the supplied unit.
-func (r *Relation) CAASUnit(u *CAASUnit) (*RelationUnit, error) {
+func (r *Relation) Unit(u *CAASUnit) (*RelationUnit, error) {
 	if u == nil {
 		return nil, fmt.Errorf("unit is nil")
 	}

--- a/apiserver/caasoperator/facade.go
+++ b/apiserver/caasoperator/facade.go
@@ -608,7 +608,7 @@ func (f *Facade) RelationById(args params.RelationIds) (params.RelationResults, 
 	return result, nil
 }
 
-// JoinedRelations returns the tags of all relations for which each supplied unit
+// JoinedRelations returns the tags of all relations for which each supplied application
 // has entered scope. It should be called RelationsInScope, but it's not convenient
 // to make that change until we have versioned APIs.
 func (f *Facade) JoinedRelations(args params.Entities) (params.StringsResults, error) {
@@ -636,7 +636,6 @@ func (f *Facade) JoinedRelations(args params.Entities) (params.StringsResults, e
 	}
 	return result, nil
 }
-
 
 // EnterScope ensures each unit has entered its scope in the relation,
 // for all of the given relation/unit pairs. See also

--- a/state/application.go
+++ b/state/application.go
@@ -1418,7 +1418,7 @@ func (a *Application) Relations() (relations []*Relation, err error) {
 	return applicationRelations(a.st, a.doc.Name)
 }
 
-func applicationRelations(st *State, name string) (relations []*Relation, err error) {
+func applicationRelations(st modelBackend, name string) (relations []*Relation, err error) {
 	defer errors.DeferredAnnotatef(&err, "can't get relations for application %q", name)
 	relationsCollection, closer := st.db().GetCollection(relationsC)
 	defer closer()

--- a/state/caasapplication.go
+++ b/state/caasapplication.go
@@ -658,10 +658,9 @@ func caasApplicationRelations(st *CAASState, name string) (relations []*Relation
 	if err != nil {
 		return nil, err
 	}
-	// XXX
-	// for _, v := range docs {
-	// 	relations = append(relations, newRelation(st, &v))
-	// }
+	for _, v := range docs {
+		relations = append(relations, newRelation(st, &v))
+	}
 	return relations, nil
 }
 

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -185,6 +185,8 @@ func (st *CAASState) FindEntity(tag names.Tag) (Entity, error) {
 		return st.User(tag)
 	case names.ApplicationTag:
 		return st.CAASApplication(id)
+	case names.UnitTag:
+		return st.CAASUnit(id)
 	default:
 		return nil, errors.Errorf("unsupported tag %T", tag)
 	}

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -694,8 +694,3 @@ func (st *CAASState) Relation(id int) (*Relation, error) {
 func (st *CAASState) AllRelations() (relations []*Relation, err error) {
 	return allRelations(st)
 }
-
-// Relation returns the existing relation with the given id.
-func (st *CAASState) Relation(id int) (*Relation, error) {
-	return relation(st, id)
-}

--- a/state/caasstate.go
+++ b/state/caasstate.go
@@ -694,3 +694,8 @@ func (st *CAASState) Relation(id int) (*Relation, error) {
 func (st *CAASState) AllRelations() (relations []*Relation, err error) {
 	return allRelations(st)
 }
+
+// Relation returns the existing relation with the given id.
+func (st *CAASState) Relation(id int) (*Relation, error) {
+	return relation(st, id)
+}

--- a/state/caasunit.go
+++ b/state/caasunit.go
@@ -352,40 +352,40 @@ func (u *CAASUnit) Resolved() ResolvedMode {
 
 // RelationsJoined returns the relations for which the unit has entered scope
 // and neither left it nor prepared to leave it
-// func (u *CAASUnit) RelationsJoined() ([]*Relation, error) {
-// 	return u.relations(func(ru *RelationUnit) (bool, error) {
-// 		return ru.Joined()
-// 	})
-// }
+func (u *CAASUnit) RelationsJoined() ([]*Relation, error) {
+	return u.relations(func(ru *RelationUnit) (bool, error) {
+		return ru.Joined()
+	})
+}
 
-// // RelationsInScope returns the relations for which the unit has entered scope
-// // and not left it.
-// func (u *CAASUnit) RelationsInScope() ([]*Relation, error) {
-// 	return u.relations(func(ru *RelationUnit) (bool, error) {
-// 		return ru.InScope()
-// 	})
-// }
+// RelationsInScope returns the relations for which the unit has entered scope
+// and not left it.
+func (u *CAASUnit) RelationsInScope() ([]*Relation, error) {
+	return u.relations(func(ru *RelationUnit) (bool, error) {
+		return ru.InScope()
+	})
+}
 
-// // relations implements RelationsJoined and RelationsInScope.
-// func (u *CAASUnit) relations(predicate relationPredicate) ([]*Relation, error) {
-// 	candidates, err := applicationRelations(u.st, u.doc.CAASApplication)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	var filtered []*Relation
-// 	for _, relation := range candidates {
-// 		relationUnit, err := relation.Unit(u)
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 		if include, err := predicate(relationUnit); err != nil {
-// 			return nil, err
-// 		} else if include {
-// 			filtered = append(filtered, relation)
-// 		}
-// 	}
-// 	return filtered, nil
-// }
+// relations implements RelationsJoined and RelationsInScope.
+func (u *CAASUnit) relations(predicate relationPredicate) ([]*Relation, error) {
+	candidates, err := applicationRelations(u.st, u.doc.CAASApplication)
+	if err != nil {
+		return nil, err
+	}
+	var filtered []*Relation
+	for _, relation := range candidates {
+		relationUnit, err := relation.CAASUnit(u)
+		if err != nil {
+			return nil, err
+		}
+		if include, err := predicate(relationUnit); err != nil {
+			return nil, err
+		} else if include {
+			filtered = append(filtered, relation)
+		}
+	}
+	return filtered, nil
+}
 
 // // DeployerTag returns the tag of the agent responsible for deploying
 // // the unit. If no such entity can be determined, false is returned.

--- a/state/relation.go
+++ b/state/relation.go
@@ -401,6 +401,13 @@ func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
 	return r.unit(u.Name(), u.doc.Principal, u.IsPrincipal(), checkUnitLife)
 }
 
+// XXX CAAS: since r.unit() just takes the unit name, we should have one function
+// here that takes some interface that covers both Unit and CAASUnit
+func (r *Relation) CAASUnit(u *CAASUnit) (*RelationUnit, error) {
+	const checkUnitLife = true
+	return r.unit(u.Name(), "", true, checkUnitLife)
+}
+
 // RemoteUnit returns a RelationUnit for the supplied unit
 // of a remote application.
 func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {

--- a/state/relation.go
+++ b/state/relation.go
@@ -401,13 +401,6 @@ func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
 	return r.unit(u.Name(), u.doc.Principal, u.IsPrincipal(), checkUnitLife)
 }
 
-// XXX CAAS: since r.unit() just takes the unit name, we should have one function
-// here that takes some interface that covers both Unit and CAASUnit
-func (r *Relation) CAASUnit(u *CAASUnit) (*RelationUnit, error) {
-	const checkUnitLife = true
-	return r.unit(u.Name(), "", true, checkUnitLife)
-}
-
 // RemoteUnit returns a RelationUnit for the supplied unit
 // of a remote application.
 func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -90,12 +90,23 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	relationDocID := ru.relation.doc.DocID
 	var ops []txn.Op
 	if ru.checkUnitLife {
-		// XXX CAAS
-		ops = append(ops, txn.Op{
-			C:      unitsC,
-			Id:     ru.unitName,
-			Assert: isAliveDoc,
-		})
+		_, ok := ru.st.(*State)
+		if ok {
+
+			ops = append(ops, txn.Op{
+				C:      unitsC,
+				Id:     ru.unitName,
+				Assert: isAliveDoc,
+			})
+
+		} else {
+			ops = append(ops, txn.Op{
+				C:      caasUnitsC,
+				Id:     ru.unitName,
+				Assert: isAliveDoc,
+			})
+
+		}
 		ops = append(ops, txn.Op{
 			C:      relationsC,
 			Id:     relationDocID,

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -426,8 +426,12 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 func (ru *RelationUnit) SettingsAddress() (network.Address, error) {
 	st, ok := ru.st.(*State)
 	if !ok {
-		// XXX CAAS
-		return network.Address{}, errors.New("unsupported")
+		st := ru.st.(*CAASState)
+		unit, err := st.CAASUnit(ru.unitName)
+		if err != nil {
+			return network.Address{}, errors.Trace(err)
+		}
+		return unit.PrivateAddress()
 	}
 
 	unit, err := st.Unit(ru.unitName)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1364,6 +1364,11 @@ func (u *Unit) Watch() NotifyWatcher {
 	return newEntityWatcher(u.st, unitsC, u.doc.DocID)
 }
 
+// Watch returns a watcher for observing changes to a unit.
+func (u *CAASUnit) Watch() NotifyWatcher {
+	return newEntityWatcher(u.st, caasUnitsC, u.doc.DocID)
+}
+
 // Watch returns a watcher for observing changes to a model.
 func (e *Model) Watch() NotifyWatcher {
 	return newEntityWatcher(e.st, modelsC, e.doc.UUID)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -413,7 +413,7 @@ func watchApplicationRelations(backend modelBackend, applicationName string) Str
 		out := strings.HasPrefix(k, prefix) || strings.Contains(k, infix)
 		return out
 	}
-
+	logger.Debugf("starting lifecycle watcher for relations with applicationName: %v", applicationName)
 	members := bson.D{{"endpoints.applicationname", applicationName}}
 	return newLifecycleWatcher(backend, relationsC, members, filter, nil)
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -392,6 +392,10 @@ func (a *Application) WatchRelations() StringsWatcher {
 	return watchApplicationRelations(a.st, a.doc.Name)
 }
 
+func (a *CAASApplication) WatchRelations() StringsWatcher {
+	return watchApplicationRelations(a.st, a.doc.Name)
+}
+
 // WatchRelations returns a StringsWatcher that notifies of changes to the
 // lifecycles of relations involving s.
 func (s *RemoteApplication) WatchRelations() StringsWatcher {

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -256,11 +256,10 @@ func (op *CaasOperator) loop(applicationTag names.ApplicationTag) (err error) {
 	}
 
 	clearResolved := func() error {
-		/* MMCC - need to know which unit to clear
 		if err := op.caasunit.ClearResolved(); err != nil {
 			return errors.Trace(err)
 		}
-		*/
+
 		watcher.ClearResolvedMode()
 		return nil
 	}
@@ -411,7 +410,7 @@ func (op *CaasOperator) init(caasapplicationtag names.ApplicationTag) (err error
 
 	relations, err := relation.NewRelations(
 		op.st, op.caasunit.Tag(), op.paths.State.CharmDir,
-		op.paths.State.CharmDir, op.catacomb.Dying(),
+		op.paths.State.RelationsDir, op.catacomb.Dying(),
 	)
 	if err != nil {
 		return errors.Annotatef(err, "cannot create relations for unit %v",
@@ -437,7 +436,7 @@ func (op *CaasOperator) init(caasapplicationtag names.ApplicationTag) (err error
 
 	contextFactory, err := context.NewContextFactory(
 		op.st, caasapplicationtag,
-		nil, // XXX op.relations.GetInfo,
+		op.relations.GetInfo,
 		op.paths, op.clock,
 	)
 	if err != nil {

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -19,11 +19,6 @@ import (
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 
-	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/rest"
-
 	"github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
@@ -163,23 +158,6 @@ func (op *CaasOperator) loop(caasoperatortag names.ApplicationTag) (err error) {
 		}
 		return errors.Annotatef(err, "failed to initialize caasoperator for %q", caasoperatortag)
 	}
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
-	}
-
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	pods, err := clientset.CoreV1().Pods("").List(v1.ListOptions{})
-	if err != nil {
-		panic(err.Error())
-	}
-	logger.Errorf("Kubes: There are %d pods in the cluster\n", len(pods.Items))
 
 	// Install is a special case, as it must run before there
 	// is any remote state, and before the remote state watcher

--- a/worker/caasoperator/relation/relations.go
+++ b/worker/caasoperator/relation/relations.go
@@ -10,7 +10,7 @@ import (
 	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	//	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/apiserver/params"
@@ -104,10 +104,12 @@ func NewRelations(st *caasoperator.State, tag names.UnitTag, charmDir, relations
 // the corresponding relations. It's only expected to be called while a
 // *relations is being created.
 func (r *relations) init() error {
+	logger.Debugf("in relations.init()")
 	joinedRelationTags, err := r.caasUnit.JoinedRelations()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	logger.Debugf("relations.init(), got joinedRelationTags = %v", joinedRelationTags)
 	joinedRelations := make(map[int]*caasoperator.Relation)
 	for _, tag := range joinedRelationTags {
 		relation, err := r.st.Relation(tag)
@@ -116,10 +118,13 @@ func (r *relations) init() error {
 		}
 		joinedRelations[relation.Id()] = relation
 	}
+	logger.Debugf("relations.init(), got joinedRelations = %v", joinedRelations)
 	knownDirs, err := ReadAllStateDirs(r.relationsDir)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	logger.Debugf("relations.init(), got knownDirs = %v", knownDirs)
 	for id, dir := range knownDirs {
 		if rel, ok := joinedRelations[id]; ok {
 			if err := r.add(rel, dir); err != nil {
@@ -390,7 +395,7 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 // operation succeeds or fails; or until the abort chan is closed, in
 // which case it will return resolver.ErrLoopAborted.
 func (r *relations) add(rel *caasoperator.Relation, dir *StateDir) (err error) {
-	logger.Infof("joining relation %q, storing state in %v", rel, dir)
+	logger.Infof("relations.add(): %q, storing state in %v", rel, dir)
 	ru, err := rel.CAASUnit(r.caasUnit)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/caasoperator/relation/relations.go
+++ b/worker/caasoperator/relation/relations.go
@@ -10,7 +10,7 @@ import (
 	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 	"gopkg.in/juju/names.v2"
-	//	worker "gopkg.in/juju/worker.v1"
+	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/apiserver/params"
@@ -396,7 +396,7 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 // which case it will return resolver.ErrLoopAborted.
 func (r *relations) add(rel *caasoperator.Relation, dir *StateDir) (err error) {
 	logger.Infof("relations.add(): %q, storing state in %v", rel, dir)
-	ru, err := rel.CAASUnit(r.caasUnit)
+	ru, err := rel.Unit(r.caasUnit)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/caasoperator/relation/relations.go
+++ b/worker/caasoperator/relation/relations.go
@@ -7,10 +7,13 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
+	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/caasoperator"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/caasoperator/hook"
 	"github.com/juju/juju/worker/caasoperator/operation"
 	"github.com/juju/juju/worker/caasoperator/remotestate"
@@ -70,7 +73,7 @@ func (s *relationsResolver) NextOp(
 // relations implements Relations.
 type relations struct {
 	st           *caasoperator.State
-	application  *caasoperator.CAASApplication
+	caasUnit     *caasoperator.CAASUnit
 	charmDir     string
 	relationsDir string
 	relationers  map[int]*Relationer
@@ -78,70 +81,67 @@ type relations struct {
 }
 
 // NewRelations returns a new Relations instance.
-func NewRelations(st *caasoperator.State, tag names.ApplicationTag, charmDir, relationsDir string, abort <-chan struct{}) (Relations, error) {
-	// unit, err := st.Unit(tag)
-	// if err != nil {
-	// 	return nil, errors.Trace(err)
-	// }
-	// r := &relations{
-	// 	st:           st,
-	// 	unit:         unit,
-	// 	charmDir:     charmDir,
-	// 	relationsDir: relationsDir,
-	// 	relationers:  make(map[int]*Relationer),
-	// 	abort:        abort,
-	// }
-	// if err := r.init(); err != nil {
-	// 	return nil, errors.Trace(err)
-	// }
-	// return r, nil
-	logger.Errorf("Unimplemented NewRelations")
-	return nil, nil
+func NewRelations(st *caasoperator.State, tag names.UnitTag, charmDir, relationsDir string, abort <-chan struct{}) (Relations, error) {
+	unit, err := st.CAASUnit(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	r := &relations{
+		st:           st,
+		caasUnit:     unit,
+		charmDir:     charmDir,
+		relationsDir: relationsDir,
+		relationers:  make(map[int]*Relationer),
+		abort:        abort,
+	}
+	if err := r.init(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return r, nil
 }
 
 // init reconciles the local relation state dirs with the remote state of
 // the corresponding relations. It's only expected to be called while a
 // *relations is being created.
 func (r *relations) init() error {
-	return errors.Errorf("Unimplemented relations.init")
-	// joinedRelationTags, err := r.unit.JoinedRelations()
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// joinedRelations := make(map[int]*caasoperator.Relation)
-	// for _, tag := range joinedRelationTags {
-	// 	relation, err := r.st.Relation(tag)
-	// 	if err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// 	joinedRelations[relation.Id()] = relation
-	// }
-	// knownDirs, err := ReadAllStateDirs(r.relationsDir)
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// for id, dir := range knownDirs {
-	// 	if rel, ok := joinedRelations[id]; ok {
-	// 		if err := r.add(rel, dir); err != nil {
-	// 			return errors.Trace(err)
-	// 		}
-	// 	} else if err := dir.Remove(); err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// }
-	// for id, rel := range joinedRelations {
-	// 	if _, ok := knownDirs[id]; ok {
-	// 		continue
-	// 	}
-	// 	dir, err := ReadStateDir(r.relationsDir, id)
-	// 	if err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// 	if err := r.add(rel, dir); err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// }
-	// return nil
+	joinedRelationTags, err := r.caasUnit.JoinedRelations()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	joinedRelations := make(map[int]*caasoperator.Relation)
+	for _, tag := range joinedRelationTags {
+		relation, err := r.st.Relation(tag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		joinedRelations[relation.Id()] = relation
+	}
+	knownDirs, err := ReadAllStateDirs(r.relationsDir)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for id, dir := range knownDirs {
+		if rel, ok := joinedRelations[id]; ok {
+			if err := r.add(rel, dir); err != nil {
+				return errors.Trace(err)
+			}
+		} else if err := dir.Remove(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	for id, rel := range joinedRelations {
+		if _, ok := knownDirs[id]; ok {
+			continue
+		}
+		dir, err := ReadStateDir(r.relationsDir, id)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := r.add(rel, dir); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 // NextHook implements Relations.
@@ -149,61 +149,36 @@ func (r *relations) NextHook(
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 ) (hook.Info, error) {
-	return hook.Info{}, errors.Errorf("unimplemented NextHook")
-	// if remoteState.Life == params.Dying {
-	// 	// The unit is Dying, so make sure all subordinates are dying.
-	// 	var destroyAllSubordinates bool
-	// 	for relationId, relationSnapshot := range remoteState.Relations {
-	// 		if relationSnapshot.Life != params.Alive {
-	// 			continue
-	// 		}
-	// 		relationer, ok := r.relationers[relationId]
-	// 		if !ok {
-	// 			continue
-	// 		}
-	// 		if relationer.ru.Endpoint().Scope == corecharm.ScopeContainer {
-	// 			relationSnapshot.Life = params.Dying
-	// 			remoteState.Relations[relationId] = relationSnapshot
-	// 			destroyAllSubordinates = true
-	// 		}
-	// 	}
-	// 	if destroyAllSubordinates {
-	// 		if err := r.unit.DestroyAllSubordinates(); err != nil {
-	// 			return hook.Info{}, errors.Trace(err)
-	// 		}
-	// 	}
-	// }
+	// Add/remove local relation state; enter and leave scope as necessary.
+	if err := r.update(remoteState.Relations); err != nil {
+		return hook.Info{}, errors.Trace(err)
+	}
 
-	// // Add/remove local relation state; enter and leave scope as necessary.
-	// if err := r.update(remoteState.Relations); err != nil {
-	// 	return hook.Info{}, errors.Trace(err)
-	// }
+	if localState.Kind != operation.Continue {
+		return hook.Info{}, resolver.ErrNoOperation
+	}
 
-	// if localState.Kind != operation.Continue {
-	// 	return hook.Info{}, resolver.ErrNoOperation
-	// }
-
-	// // See if any of the relations have operations to perform.
-	// for relationId, relationSnapshot := range remoteState.Relations {
-	// 	relationer, ok := r.relationers[relationId]
-	// 	if !ok || relationer.IsImplicit() {
-	// 		continue
-	// 	}
-	// 	var remoteBroken bool
-	// 	if remoteState.Life == params.Dying || relationSnapshot.Life == params.Dying {
-	// 		relationSnapshot = remotestate.RelationSnapshot{}
-	// 		remoteBroken = true
-	// 		// TODO(axw) if relation is implicit, leave scope & remove.
-	// 	}
-	// 	// If either the unit or the relation are Dying,
-	// 	// then the relation should be broken.
-	// 	hook, err := nextRelationHook(relationer.dir.State(), relationSnapshot, remoteBroken)
-	// 	if err == resolver.ErrNoOperation {
-	// 		continue
-	// 	}
-	// 	return hook, err
-	// }
-	// return hook.Info{}, resolver.ErrNoOperation
+	// See if any of the relations have operations to perform.
+	for relationId, relationSnapshot := range remoteState.Relations {
+		relationer, ok := r.relationers[relationId]
+		if !ok || relationer.IsImplicit() {
+			continue
+		}
+		var remoteBroken bool
+		if remoteState.Life == params.Dying || relationSnapshot.Life == params.Dying {
+			relationSnapshot = remotestate.RelationSnapshot{}
+			remoteBroken = true
+			// TODO(axw) if relation is implicit, leave scope & remove.
+		}
+		// If either the unit or the relation are Dying,
+		// then the relation should be broken.
+		hook, err := nextRelationHook(relationer.dir.State(), relationSnapshot, remoteBroken)
+		if err == resolver.ErrNoOperation {
+			continue
+		}
+		return hook, err
+	}
+	return hook.Info{}, resolver.ErrNoOperation
 }
 
 // nextRelationHook returns the next hook op that should be executed in the
@@ -355,73 +330,59 @@ func (r *relations) GetInfo() map[int]*context.RelationInfo {
 }
 
 func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
-	return errors.Errorf("unimplemented update")
-	// for id, relationSnapshot := range remote {
-	// 	if _, found := r.relationers[id]; found {
-	// 		// We've seen this relation before. The only changes
-	// 		// we care about are to the lifecycle state, and to
-	// 		// the member settings versions. We handle differences
-	// 		// in settings in nextRelationHook.
-	// 		if relationSnapshot.Life == params.Dying {
-	// 			if err := r.setDying(id); err != nil {
-	// 				return errors.Trace(err)
-	// 			}
-	// 		}
-	// 		continue
-	// 	}
-	// 	// Relations that are not alive are simply skipped, because they
-	// 	// were not previously known anyway.
-	// 	if relationSnapshot.Life != params.Alive {
-	// 		continue
-	// 	}
-	// 	rel, err := r.st.RelationById(id)
-	// 	if err != nil {
-	// 		if params.IsCodeNotFoundOrCodeUnauthorized(err) {
-	// 			continue
-	// 		}
-	// 		return errors.Trace(err)
-	// 	}
-	// 	// Make sure we ignore relations not implemented by the unit's charm.
-	// 	ch, err := corecharm.ReadCharmDir(r.charmDir)
-	// 	if err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// 	if ep, err := rel.Endpoint(); err != nil {
-	// 		return errors.Trace(err)
-	// 	} else if !ep.ImplementedBy(ch) {
-	// 		logger.Warningf("skipping relation with unknown endpoint %q", ep.Name)
-	// 		continue
-	// 	}
-	// 	dir, err := ReadStateDir(r.relationsDir, id)
-	// 	if err != nil {
-	// 		return errors.Trace(err)
-	// 	}
-	// 	addErr := r.add(rel, dir)
-	// 	if addErr == nil {
-	// 		continue
-	// 	}
-	// 	removeErr := dir.Remove()
-	// 	if !params.IsCodeCannotEnterScope(addErr) {
-	// 		return errors.Trace(addErr)
-	// 	}
-	// 	if removeErr != nil {
-	// 		return errors.Trace(removeErr)
-	// 	}
-	// }
-	// if ok, err := r.unit.IsPrincipal(); err != nil {
-	// 	return errors.Trace(err)
-	// } else if ok {
-	// 	return nil
-	// }
-	// // If no Alive relations remain between a subordinate unit's service
-	// // and its principal's service, the subordinate must become Dying.
-	// for _, relationer := range r.relationers {
-	// 	scope := relationer.ru.Endpoint().Scope
-	// 	if scope == corecharm.ScopeContainer && !relationer.dying {
-	// 		return nil
-	// 	}
-	// }
-	// return r.unit.Destroy()
+	for id, relationSnapshot := range remote {
+		if _, found := r.relationers[id]; found {
+			// We've seen this relation before. The only changes
+			// we care about are to the lifecycle state, and to
+			// the member settings versions. We handle differences
+			// in settings in nextRelationHook.
+			if relationSnapshot.Life == params.Dying {
+				if err := r.setDying(id); err != nil {
+					return errors.Trace(err)
+				}
+			}
+			continue
+		}
+		// Relations that are not alive are simply skipped, because they
+		// were not previously known anyway.
+		if relationSnapshot.Life != params.Alive {
+			continue
+		}
+		rel, err := r.st.RelationById(id)
+		if err != nil {
+			if params.IsCodeNotFoundOrCodeUnauthorized(err) {
+				continue
+			}
+			return errors.Trace(err)
+		}
+		// Make sure we ignore relations not implemented by the unit's charm.
+		ch, err := corecharm.ReadCharmDir(r.charmDir)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if ep, err := rel.Endpoint(); err != nil {
+			return errors.Trace(err)
+		} else if !ep.ImplementedBy(ch) {
+			logger.Warningf("skipping relation with unknown endpoint %q", ep.Name)
+			continue
+		}
+		dir, err := ReadStateDir(r.relationsDir, id)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		addErr := r.add(rel, dir)
+		if addErr == nil {
+			continue
+		}
+		removeErr := dir.Remove()
+		if !params.IsCodeCannotEnterScope(addErr) {
+			return errors.Trace(addErr)
+		}
+		if removeErr != nil {
+			return errors.Trace(removeErr)
+		}
+	}
+	return nil
 }
 
 // add causes the unit agent to join the supplied relation, and to
@@ -429,48 +390,47 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 // operation succeeds or fails; or until the abort chan is closed, in
 // which case it will return resolver.ErrLoopAborted.
 func (r *relations) add(rel *caasoperator.Relation, dir *StateDir) (err error) {
-	return errors.Errorf("unimplemented relation add")
-	// logger.Infof("joining relation %q", rel)
-	// ru, err := rel.Unit(r.unit)
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// relationer := NewRelationer(ru, dir)
-	// unitWatcher, err := r.unit.Watch()
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// defer func() {
-	// 	if e := worker.Stop(unitWatcher); e != nil {
-	// 		if err == nil {
-	// 			err = e
-	// 		} else {
-	// 			logger.Errorf("while stopping unit watcher: %v", e)
-	// 		}
-	// 	}
-	// }()
-	// for {
-	// 	select {
-	// 	case <-r.abort:
-	// 		// Should this be a different error? e.g. resolver.ErrAborted, that
-	// 		// Loop translates into ErrLoopAborted?
-	// 		return resolver.ErrLoopAborted
-	// 	case _, ok := <-unitWatcher.Changes():
-	// 		if !ok {
-	// 			return errors.New("unit watcher closed")
-	// 		}
-	// 		err := relationer.Join()
-	// 		if params.IsCodeCannotEnterScopeYet(err) {
-	// 			logger.Infof("cannot enter scope for relation %q; waiting for subordinate to be removed", rel)
-	// 			continue
-	// 		} else if err != nil {
-	// 			return errors.Trace(err)
-	// 		}
-	// 		logger.Infof("joined relation %q", rel)
-	// 		r.relationers[rel.Id()] = relationer
-	// 		return nil
-	// 	}
-	// }
+	logger.Infof("joining relation %q, storing state in %v", rel, dir)
+	ru, err := rel.CAASUnit(r.caasUnit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	relationer := NewRelationer(ru, dir)
+	unitWatcher, err := r.caasUnit.Watch()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() {
+		if e := worker.Stop(unitWatcher); e != nil {
+			if err == nil {
+				err = e
+			} else {
+				logger.Errorf("while stopping unit watcher: %v", e)
+			}
+		}
+	}()
+	for {
+		select {
+		case <-r.abort:
+			// Should this be a different error? e.g. resolver.ErrAborted, that
+			// Loop translates into ErrLoopAborted?
+			return resolver.ErrLoopAborted
+		case _, ok := <-unitWatcher.Changes():
+			if !ok {
+				return errors.New("unit watcher closed")
+			}
+			err := relationer.Join()
+			if params.IsCodeCannotEnterScopeYet(err) {
+				logger.Infof("cannot enter scope for relation %q; waiting for subordinate to be removed", rel)
+				continue
+			} else if err != nil {
+				return errors.Trace(err)
+			}
+			logger.Infof("joined relation %q", rel)
+			r.relationers[rel.Id()] = relationer
+			return nil
+		}
+	}
 }
 
 // setDying notifies the relationer identified by the supplied id that the

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -168,7 +168,7 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 	if err := w.setUp(caasApplicationTag); err != nil {
 		return errors.Trace(err)
 	}
-
+	logger.Debugf("remotestatewatcher setup correctly.")
 	var requiredEvents int
 
 	var seenApplicationChange bool
@@ -180,6 +180,7 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 		return errors.Trace(err)
 	}
 	requiredEvents++
+	logger.Debugf("app.watch created.")
 
 	var seenUnitsChange bool
 	unitsw, err := w.app.WatchUnits()
@@ -190,7 +191,7 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 		return errors.Trace(err)
 	}
 	requiredEvents++
-
+	logger.Debugf("watchunits created.")
 	// var seenConfigChange bool
 	// configw, err := w.unit.WatchConfigSettings()
 	// if err != nil {
@@ -210,6 +211,7 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 		return errors.Trace(err)
 	}
 	requiredEvents++
+	logger.Debugf("relationsw created.")
 
 	// var seenAddressesChange bool
 	// addressesw, err := w.unit.WatchAddresses()
@@ -440,6 +442,8 @@ func (w *RemoteStateWatcher) addressesChanged() error {
 func (w *RemoteStateWatcher) relationsChanged(keys []string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	logger.Debugf("in RemoteStateWatcher.relationsChanged, keys = %v", keys)
+
 	for _, key := range keys {
 		relationTag := names.NewRelationTag(key)
 		rel, err := w.st.Relation(relationTag)

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -161,6 +161,15 @@ func (w *RemoteStateWatcher) setUp(applicationtag names.ApplicationTag) (err err
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	fakeCaasUnitTag, err := names.ParseUnitTag("unit-" + applicationtag.Id() + "/0")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	w.caasUnit, err = w.st.CAASUnit(fakeCaasUnitTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
@@ -24,6 +25,7 @@ var logger = loggo.GetLogger("juju.worker.caasoperator.remotestate")
 // channel upon change.
 type RemoteStateWatcher struct {
 	st                        State
+	caasUnit                  CAASUnit
 	app                       CAASApplication
 	relations                 map[names.RelationTag]*relationUnitsWatcher
 	relationUnitsChanges      chan relationUnitsChange
@@ -199,15 +201,15 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 	// }
 	// requiredEvents++
 
-	// var seenRelationsChange bool
-	// relationsw, err := w.app.WatchRelations()
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// if err := w.catacomb.Add(relationsw); err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// requiredEvents++
+	var seenRelationsChange bool
+	relationsw, err := w.app.WatchRelations()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(relationsw); err != nil {
+		return errors.Trace(err)
+	}
+	requiredEvents++
 
 	// var seenAddressesChange bool
 	// addressesw, err := w.unit.WatchAddresses()
@@ -304,15 +306,15 @@ func (w *RemoteStateWatcher) loop(caasApplicationTag names.ApplicationTag) (err 
 		// 	}
 		// 	observedEvent(&seenActionsChange)
 
-		// case keys, ok := <-relationsw.Changes():
-		// 	logger.Debugf("got relations change: ok=%t", ok)
-		// 	if !ok {
-		// 		return errors.New("relations watcher closed")
-		// 	}
-		// 	if err := w.relationsChanged(keys); err != nil {
-		// 		return errors.Trace(err)
-		// 	}
-		// 	observedEvent(&seenRelationsChange)
+		case keys, ok := <-relationsw.Changes():
+			logger.Debugf("got relations change: ok=%t", ok)
+			if !ok {
+				return errors.New("relations watcher closed")
+			}
+			if err := w.relationsChanged(keys); err != nil {
+				return errors.Trace(err)
+			}
+			observedEvent(&seenRelationsChange)
 
 		// case keys, ok := <-storagew.Changes():
 		// 	logger.Debugf("got storage change: %v ok=%t", keys, ok)
@@ -436,44 +438,43 @@ func (w *RemoteStateWatcher) addressesChanged() error {
 
 // relationsChanged responds to app relation changes.
 func (w *RemoteStateWatcher) relationsChanged(keys []string) error {
-	// XXX CAAS
-	// w.mu.Lock()
-	// defer w.mu.Unlock()
-	// for _, key := range keys {
-	// 	relationTag := names.NewRelationTag(key)
-	// 	rel, err := w.st.Relation(relationTag)
-	// 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
-	// 		// If it's actually gone, this unit cannot have entered
-	// 		// scope, and therefore never needs to know about it.
-	// 		if ruw, ok := w.relations[relationTag]; ok {
-	// 			worker.Stop(ruw)
-	// 			delete(w.relations, relationTag)
-	// 			delete(w.current.Relations, ruw.relationId)
-	// 		}
-	// 	} else if err != nil {
-	// 		return errors.Trace(err)
-	// 	} else {
-	// 		if _, ok := w.relations[relationTag]; ok {
-	// 			relationSnapshot := w.current.Relations[rel.Id()]
-	// 			relationSnapshot.Life = rel.Life()
-	// 			w.current.Relations[rel.Id()] = relationSnapshot
-	// 			continue
-	// 		}
-	// 		ruw, err := w.st.WatchRelationUnits(relationTag, w.caasUnit.Tag())
-	// 		if err != nil {
-	// 			return errors.Trace(err)
-	// 		}
-	// 		Because of the delay before handing off responsibility to
-	// 		newRelationUnitsWatcher below, add to our own catacomb to
-	// 		ensure errors get picked up if they happen.
-	// 		if err := w.catacomb.Add(ruw); err != nil {
-	// 			return errors.Trace(err)
-	// 		}
-	// 		if err := w.watchRelationUnits(rel, relationTag, ruw); err != nil {
-	// 			return errors.Trace(err)
-	// 		}
-	// 	}
-	// }
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, key := range keys {
+		relationTag := names.NewRelationTag(key)
+		rel, err := w.st.Relation(relationTag)
+		if params.IsCodeNotFoundOrCodeUnauthorized(err) {
+			// If it's actually gone, this unit cannot have entered
+			// scope, and therefore never needs to know about it.
+			if ruw, ok := w.relations[relationTag]; ok {
+				worker.Stop(ruw)
+				delete(w.relations, relationTag)
+				delete(w.current.Relations, ruw.relationId)
+			}
+		} else if err != nil {
+			return errors.Trace(err)
+		} else {
+			if _, ok := w.relations[relationTag]; ok {
+				relationSnapshot := w.current.Relations[rel.Id()]
+				relationSnapshot.Life = rel.Life()
+				w.current.Relations[rel.Id()] = relationSnapshot
+				continue
+			}
+			ruw, err := w.st.WatchRelationUnits(relationTag, w.caasUnit.Tag())
+			if err != nil {
+				return errors.Trace(err)
+			}
+			// Because of the delay before handing off responsibility to
+			// newRelationUnitsWatcher below, add to our own catacomb to
+			// ensure errors get picked up if they happen.
+			if err := w.catacomb.Add(ruw); err != nil {
+				return errors.Trace(err)
+			}
+			if err := w.watchRelationUnits(rel, relationTag, ruw); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/worker/caasoperator/resolver.go
+++ b/worker/caasoperator/resolver.go
@@ -260,6 +260,7 @@ func (s *caasoperatorResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 
+	logger.Debugf("about to see if RelationsResolver has a next op for remote state = %v and local state = %v")
 	op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err

--- a/worker/caasoperator/resolver.go
+++ b/worker/caasoperator/resolver.go
@@ -223,11 +223,10 @@ func (s *caasoperatorResolver) nextOp(
 	case params.Dying:
 		// Normally we handle relations last, but if we're dying we
 		// must ensure that all relations are broken first.
-		// XXX CAAS
-		// op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
-		// if errors.Cause(err) != resolver.ErrNoOperation {
-		// 	return op, err
-		// }
+		op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
+		if errors.Cause(err) != resolver.ErrNoOperation {
+			return op, err
+		}
 
 		// We're not in a hook error and the unit is Dying,
 		// so we should proceed to tear down.
@@ -261,11 +260,10 @@ func (s *caasoperatorResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 
-	// XXX CAAS
-	// op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
-	// if errors.Cause(err) != resolver.ErrNoOperation {
-	// 	return op, err
-	// }
+	op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
+	if errors.Cause(err) != resolver.ErrNoOperation {
+		return op, err
+	}
 
 	// UpdateStatus hook runs if nothing else needs to.
 	if localState.UpdateStatusVersion != remoteState.UpdateStatusVersion {

--- a/worker/caasoperator/runner/context/contextfactory.go
+++ b/worker/caasoperator/runner/context/contextfactory.go
@@ -189,23 +189,22 @@ func (f *contextFactory) CommandContext(commandInfo CommandInfo) (*HookContext, 
 // to construct ContextRelations for a fresh context.
 func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 	contextRelations := map[int]*ContextRelation{}
-	return contextRelations // XXX CAAS
-	// relationInfos := f.getRelationInfos()
-	// relationCaches := map[int]*RelationCache{}
-	// for id, info := range relationInfos {
-	// 	relationUnit := info.RelationUnit
-	// 	memberNames := info.MemberNames
-	// 	cache, found := f.relationCaches[id]
-	// 	if found {
-	// 		cache.Prune(memberNames)
-	// 	} else {
-	// 		cache = NewRelationCache(relationUnit.ReadSettings, memberNames)
-	// 	}
-	// 	relationCaches[id] = cache
-	// 	contextRelations[id] = NewContextRelation(relationUnit, cache)
-	// }
-	// f.relationCaches = relationCaches
-	// return contextRelations
+	relationInfos := f.getRelationInfos()
+	relationCaches := map[int]*RelationCache{}
+	for id, info := range relationInfos {
+		relationUnit := info.RelationUnit
+		memberNames := info.MemberNames
+		cache, found := f.relationCaches[id]
+		if found {
+			cache.Prune(memberNames)
+		} else {
+			cache = NewRelationCache(relationUnit.ReadSettings, memberNames)
+		}
+		relationCaches[id] = cache
+		contextRelations[id] = NewContextRelation(relationUnit, cache)
+	}
+	f.relationCaches = relationCaches
+	return contextRelations
 }
 
 // updateContext fills in all unspecialized fields that require an API call to
@@ -216,38 +215,38 @@ func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 // to via hooks. Furthermore, the fact that we make multiple API calls at this
 // time, rather than grabbing everything we need in one go, is unforgivably yucky.
 func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
-	// XXX
-	// defer errors.Trace(err)
+	defer errors.Trace(err)
 
 	// ctx.apiAddrs, err = f.state.APIAddresses()
 	// if err != nil {
 	// 	return err
 	// }
-	// // ctx.machinePorts, err = f.state.AllMachinePorts(f.machineTag)
-	// // if err != nil {
-	// // 	return errors.Trace(err)
-	// // }
+
+	// ctx.machinePorts, err = f.state.AllMachinePorts(f.machineTag)
+	// if err != nil {
+	// 	return errors.Trace(err)
+	// }
 
 	// statusCode, statusInfo, err := f.caasUnit.MeterStatus()
 	// if err != nil {
 	// 	return errors.Annotate(err, "could not retrieve meter status for unit")
 	// }
-	// ctx.meterStatus = &meterStatus{
-	// 	code: statusCode,
-	// 	info: statusInfo,
-	// }
+	ctx.meterStatus = &meterStatus{
+		code: "NOT SET",
+		info: "XXX CAAS",
+	}
 
-	// // TODO(fwereade) 23-10-2014 bug 1384572
-	// // Nothing here should ever be getting the environ config directly.
+	// TODO(fwereade) 23-10-2014 bug 1384572
+	// Nothing here should ever be getting the environ config directly.
 	// modelConfig, err := f.state.ModelConfig()
 	// if err != nil {
 	// 	return err
 	// }
-	// ctx.proxySettings = modelConfig.ProxySettings()
+	//ctx.proxySettings = modelConfig.ProxySettings() // XXX CAAS MMCC
 
-	// // Calling these last, because there's a potential race: they're not guaranteed
-	// // to be set in time to be needed for a hook. If they're not, we just leave them
-	// // unset as we always have; this isn't great but it's about behaviour preservation.
+	// Calling these last, because there's a potential race: they're not guaranteed
+	// to be set in time to be needed for a hook. If they're not, we just leave them
+	// unset as we always have; this isn't great but it's about behaviour preservation.
 	// ctx.publicAddress, err = f.caasUnit.PublicAddress()
 	// if err != nil && !params.IsCodeNoAddressSet(err) {
 	// 	return err

--- a/worker/caasoperator/runner/jujuc/relation-get.go
+++ b/worker/caasoperator/runner/jujuc/relation-get.go
@@ -1,0 +1,123 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// RelationGetCommand implements the relation-get command.
+type RelationGetCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	RelationId      int
+	relationIdProxy gnuflag.Value
+
+	Key      string
+	UnitName string
+	out      cmd.Output
+}
+
+func NewRelationGetCommand(ctx Context) (cmd.Command, error) {
+	var err error
+	cmd := &RelationGetCommand{ctx: ctx}
+	cmd.relationIdProxy, err = newRelationIdValue(ctx, &cmd.RelationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return cmd, nil
+}
+
+// Info is part of the cmd.Command interface.
+func (c *RelationGetCommand) Info() *cmd.Info {
+	args := "<key> <unit id>"
+	doc := `
+relation-get prints the value of a unit's relation setting, specified by key.
+If no key is given, or if the key is "-", all keys and values will be printed.
+`
+	// There's nothing we can really do about the error here.
+	if name, err := c.ctx.RemoteUnitName(); err == nil {
+		args = "[<key> [<unit id>]]"
+		doc += fmt.Sprintf("Current default unit id is %q.", name)
+	} else if !errors.IsNotFound(err) {
+		logger.Errorf("Failed to retrieve remote unit name: %v", err)
+	}
+	return &cmd.Info{
+		Name:    "relation-get",
+		Args:    args,
+		Purpose: "get relation settings",
+		Doc:     doc,
+	}
+}
+
+// SetFlags is part of the cmd.Command interface.
+func (c *RelationGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "relation", "")
+}
+
+// Init is part of the cmd.Command interface.
+func (c *RelationGetCommand) Init(args []string) error {
+	if c.RelationId == -1 {
+		return fmt.Errorf("no relation id specified")
+	}
+	c.Key = ""
+	if len(args) > 0 {
+		if c.Key = args[0]; c.Key == "-" {
+			c.Key = ""
+		}
+		args = args[1:]
+	}
+	name, err := c.ctx.RemoteUnitName()
+	if err == nil {
+		c.UnitName = name
+	} else if cause := errors.Cause(err); !errors.IsNotFound(cause) {
+		return errors.Trace(err)
+	}
+	if len(args) > 0 {
+		c.UnitName = args[0]
+		args = args[1:]
+	}
+	if c.UnitName == "" {
+		return fmt.Errorf("no unit id specified")
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *RelationGetCommand) Run(ctx *cmd.Context) error {
+	r, err := c.ctx.Relation(c.RelationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var settings params.Settings
+	if c.UnitName == c.ctx.UnitName() {
+		node, err := r.Settings()
+		if err != nil {
+			return err
+		}
+		settings = node.Map()
+	} else {
+		var err error
+		settings, err = r.ReadSettings(c.UnitName)
+		if err != nil {
+			return err
+		}
+	}
+	if c.Key == "" {
+		return c.out.Write(ctx, settings)
+	}
+	if value, ok := settings[c.Key]; ok {
+		return c.out.Write(ctx, value)
+	}
+	return c.out.Write(ctx, nil)
+}

--- a/worker/caasoperator/runner/jujuc/relation-ids.go
+++ b/worker/caasoperator/runner/jujuc/relation-ids.go
@@ -1,0 +1,82 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+)
+
+// RelationIdsCommand implements the relation-ids command.
+type RelationIdsCommand struct {
+	cmd.CommandBase
+	ctx  Context
+	Name string
+	out  cmd.Output
+}
+
+func NewRelationIdsCommand(ctx Context) (cmd.Command, error) {
+	name := ""
+	if r, err := ctx.HookRelation(); err == nil {
+		name = r.Name()
+	} else if cause := errors.Cause(err); !errors.IsNotFound(cause) {
+		return nil, errors.Trace(err)
+	}
+
+	return &RelationIdsCommand{ctx: ctx, Name: name}, nil
+}
+
+func (c *RelationIdsCommand) Info() *cmd.Info {
+	args := "<name>"
+	doc := ""
+	if r, err := c.ctx.HookRelation(); err == nil {
+		// There's not much we can do about this error here.
+		args = "[<name>]"
+		doc = fmt.Sprintf("Current default relation name is %q.", r.Name())
+	} else if !errors.IsNotFound(err) {
+		logger.Errorf("Could not retrieve hook relation: %v", err)
+	}
+	return &cmd.Info{
+		Name:    "relation-ids",
+		Args:    args,
+		Purpose: "list all relation ids with the given relation name",
+		Doc:     doc,
+	}
+}
+
+func (c *RelationIdsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *RelationIdsCommand) Init(args []string) error {
+	if len(args) > 0 {
+		c.Name = args[0]
+		args = args[1:]
+	} else if c.Name == "" {
+		return fmt.Errorf("no relation name specified")
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *RelationIdsCommand) Run(ctx *cmd.Context) error {
+	result := []string{}
+	ids, err := c.ctx.RelationIds()
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	for _, id := range ids {
+		r, err := c.ctx.Relation(id)
+		if err == nil && r.Name() == c.Name {
+			result = append(result, r.FakeId())
+		} else if err != nil && !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+	}
+	sort.Strings(result)
+	return c.out.Write(ctx, result)
+}

--- a/worker/caasoperator/runner/jujuc/relation-list.go
+++ b/worker/caasoperator/runner/jujuc/relation-list.go
@@ -1,0 +1,71 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+)
+
+// RelationListCommand implements the relation-list command.
+type RelationListCommand struct {
+	cmd.CommandBase
+	ctx             Context
+	RelationId      int
+	relationIdProxy gnuflag.Value
+	out             cmd.Output
+}
+
+func NewRelationListCommand(ctx Context) (cmd.Command, error) {
+	c := &RelationListCommand{ctx: ctx}
+
+	rV, err := newRelationIdValue(c.ctx, &c.RelationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.relationIdProxy = rV
+
+	return c, nil
+
+}
+
+func (c *RelationListCommand) Info() *cmd.Info {
+	doc := "-r must be specified when not in a relation hook"
+	if _, err := c.ctx.HookRelation(); err == nil {
+		doc = ""
+	}
+	return &cmd.Info{
+		Name:    "relation-list",
+		Purpose: "list relation units",
+		Doc:     doc,
+	}
+}
+
+func (c *RelationListCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "relation", "")
+}
+
+func (c *RelationListCommand) Init(args []string) (err error) {
+	if c.RelationId == -1 {
+		return fmt.Errorf("no relation id specified")
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *RelationListCommand) Run(ctx *cmd.Context) error {
+	r, err := c.ctx.Relation(c.RelationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	unitNames := r.UnitNames()
+	if unitNames == nil {
+		unitNames = []string{}
+	}
+	return c.out.Write(ctx, unitNames)
+}

--- a/worker/caasoperator/runner/jujuc/relation-set.go
+++ b/worker/caasoperator/runner/jujuc/relation-set.go
@@ -1,0 +1,150 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils/keyvalues"
+	goyaml "gopkg.in/yaml.v2"
+)
+
+const relationSetDoc = `
+"relation-set" writes the local unit's settings for some relation.
+If no relation is specified then the current relation is used. The
+setting values are not inspected and are stored as strings. Setting
+an empty string causes the setting to be removed. Duplicate settings
+are not allowed.
+
+The --file option should be used when one or more key-value pairs are
+too long to fit within the command length limit of the shell or
+operating system. The file will contain a YAML map containing the
+settings.  Settings in the file will be overridden by any duplicate
+key-value arguments. A value of "-" for the filename means <stdin>.
+`
+
+// RelationSetCommand implements the relation-set command.
+type RelationSetCommand struct {
+	cmd.CommandBase
+	ctx             Context
+	RelationId      int
+	relationIdProxy gnuflag.Value
+	Settings        map[string]string
+	settingsFile    cmd.FileVar
+	formatFlag      string // deprecated
+}
+
+func NewRelationSetCommand(ctx Context) (cmd.Command, error) {
+	c := &RelationSetCommand{ctx: ctx}
+
+	rV, err := newRelationIdValue(ctx, &c.RelationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.relationIdProxy = rV
+
+	return c, nil
+}
+
+func (c *RelationSetCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "relation-set",
+		Args:    "key=value [key=value ...]",
+		Purpose: "set relation settings",
+		Doc:     relationSetDoc,
+	}
+}
+
+func (c *RelationSetCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "relation", "")
+
+	c.settingsFile.SetStdin()
+	f.Var(&c.settingsFile, "file", "file containing key-value pairs")
+
+	f.StringVar(&c.formatFlag, "format", "", "deprecated format flag")
+}
+
+func (c *RelationSetCommand) Init(args []string) error {
+	if c.RelationId == -1 {
+		return errors.Errorf("no relation id specified")
+	}
+
+	// The overrides will be applied during Run when c.settingsFile is handled.
+	overrides, err := keyvalues.Parse(args, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.Settings = overrides
+	return nil
+}
+
+func (c *RelationSetCommand) readSettings(in io.Reader) (map[string]string, error) {
+	data, err := ioutil.ReadAll(in)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	kvs := make(map[string]string)
+	if err := goyaml.Unmarshal(data, kvs); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return kvs, nil
+}
+
+func (c *RelationSetCommand) handleSettingsFile(ctx *cmd.Context) error {
+	if c.settingsFile.Path == "" {
+		return nil
+	}
+
+	file, err := c.settingsFile.Open(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer file.Close()
+
+	settings, err := c.readSettings(file)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	overrides := c.Settings
+	for k, v := range overrides {
+		settings[k] = v
+	}
+	c.Settings = settings
+	return nil
+}
+
+func (c *RelationSetCommand) Run(ctx *cmd.Context) (err error) {
+	if c.formatFlag != "" {
+		fmt.Fprintf(ctx.Stderr, "--format flag deprecated for command %q", c.Info().Name)
+	}
+	if err := c.handleSettingsFile(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
+	r, err := c.ctx.Relation(c.RelationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	settings, err := r.Settings()
+	if err != nil {
+		return errors.Annotate(err, "cannot read relation settings")
+	}
+	for k, v := range c.Settings {
+		if v != "" {
+			settings.Set(k, v)
+		} else {
+			settings.Delete(k)
+		}
+	}
+	return nil
+}

--- a/worker/caasoperator/runner/jujuc/server.go
+++ b/worker/caasoperator/runner/jujuc/server.go
@@ -52,6 +52,10 @@ var baseCommands = map[string]creator{
 	"run-container" + cmdSuffix:           NewRunContainerCommand,
 	"kill-container" + cmdSuffix:          NewKillContainerCommand,
 	"list-units" + cmdSuffix:              NewListUnitsCommand,
+	"relation-ids" + cmdSuffix:            NewRelationIdsCommand,
+	"relation-list" + cmdSuffix:           NewRelationListCommand,
+	"relation-set" + cmdSuffix:            NewRelationSetCommand,
+	"relation-get" + cmdSuffix:            NewRelationGetCommand,
 }
 
 func allEnabledCommands() map[string]creator {


### PR DESCRIPTION

Enables relation watching and relation hook firing for caasoperators.

This includes a hack to work around the fact that caasoperator is
built on the Uniter which assumes a 1:1 correspondence with units.
We simply hardcode the unit 0 tag in a few places. Caasoperator will
only successfully watch changes in unit 0 of a relation.
This should be enough functionality to evaluate charm writing in this
context.

api: adds the 1:1 hack

state: fills in a few places where CAAS support was marked as missing.
       adds Watch() to caasunit
       fixes EnterScope to create the right kind of doc for caas units

worker: re-adds some previously commented out
uniter code for relations, re-adds hook tools for relations.
